### PR TITLE
Fix watchlist update logic

### DIFF
--- a/src/components/MovieDetails/MovieDetails.tsx
+++ b/src/components/MovieDetails/MovieDetails.tsx
@@ -91,7 +91,6 @@ const MovieDetails: FC<MovieDetailProps> = ({ id, sessionData }) => {
     genres: string[],
     userRating: number
   ) => {
-    handleRemoveMovie(id)
     const movieData = createMovieObj(movie, id, genres, userRating)
     addMovie.mutateAsync({ movieData })
   }

--- a/src/server/api/routers/watchListItem.ts
+++ b/src/server/api/routers/watchListItem.ts
@@ -13,63 +13,51 @@ export const watchListItemRouter = createTRPCRouter({
       const { movieData } = input;
 
       try {
-        const movieExists = await prisma.watchListItem.findUnique({
+        const movie = await prisma.watchListItem.upsert({
           where: {
-            id: userIdNum,
-          }
-        })
-        if (movieExists) {
-          const updatedMovie = await prisma.watchListItem.update({
-            where: {
-              id: userIdNum,
-            },
-            data: {
+            userId_movieId: {
+              userId: userIdNum,
               movieId: movieData.movieId,
-              directedBy: movieData.directedBy,
-              durationMinutes: movieData.durationMinutes,
-              name: movieData.name,
-              posterImage: movieData.posterImage,
-              synopsis: movieData.synopsis,
-              tomatoMeter: movieData.tomatoMeter,
-              consensus: movieData.consensus,
-              totalGross: movieData.totalGross,
-              releaseDate: movieData.releaseDate,
-              emsVersionId: movieData.emsVersionId,
-              motionPictureRating: movieData.motionPictureRating,
-              userRating: movieData.userRating,
-              genres: [...movieData.genres],
-              user: {
-                connect: {
-                  id: userIdNum
-                }
-              }
-            }
-          })
-          return updatedMovie
-        }
-            return prisma.watchListItem.create({
-              data: {
-                movieId: movieData.movieId,
-                directedBy: movieData.directedBy,
-                durationMinutes: movieData.durationMinutes,
-                name: movieData.name,
-                posterImage: movieData.posterImage,
-                synopsis: movieData.synopsis,
-                tomatoMeter: movieData.tomatoMeter,
-                consensus: movieData.consensus,
-                totalGross: movieData.totalGross,
-                releaseDate: movieData.releaseDate,
-                emsVersionId: movieData.emsVersionId,
-                motionPictureRating: movieData.motionPictureRating,
-                userRating: movieData.userRating,
-                genres: [...movieData.genres],
-                user: {
-                  connect: {
-                    id: userIdNum,
-                  },
-                },
+            },
+          },
+          create: {
+            movieId: movieData.movieId,
+            directedBy: movieData.directedBy,
+            durationMinutes: movieData.durationMinutes,
+            name: movieData.name,
+            posterImage: movieData.posterImage,
+            synopsis: movieData.synopsis,
+            tomatoMeter: movieData.tomatoMeter,
+            consensus: movieData.consensus,
+            totalGross: movieData.totalGross,
+            releaseDate: movieData.releaseDate,
+            emsVersionId: movieData.emsVersionId,
+            motionPictureRating: movieData.motionPictureRating,
+            userRating: movieData.userRating,
+            genres: [...movieData.genres],
+            user: {
+              connect: {
+                id: userIdNum,
               },
-            })
+            },
+          },
+          update: {
+            directedBy: movieData.directedBy,
+            durationMinutes: movieData.durationMinutes,
+            name: movieData.name,
+            posterImage: movieData.posterImage,
+            synopsis: movieData.synopsis,
+            tomatoMeter: movieData.tomatoMeter,
+            consensus: movieData.consensus,
+            totalGross: movieData.totalGross,
+            releaseDate: movieData.releaseDate,
+            emsVersionId: movieData.emsVersionId,
+            motionPictureRating: movieData.motionPictureRating,
+            userRating: movieData.userRating,
+            genres: [...movieData.genres],
+          },
+        })
+        return movie
         
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (error:any) {


### PR DESCRIPTION
## Summary
- refactor server watchlist item mutation to use prisma upsert
- remove client-side deletion when rating a movie so upsert handles updates

## Testing
- `npx next lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4f0fe1c88333bceb1226d5450547