### PR TITLE
Fix security vulnerabilities: API key exposure, XSS, auth gaps

### DIFF
--- a/src/components/MovieDetails/MovieDetails.tsx
+++ b/src/components/MovieDetails/MovieDetails.tsx
@@ -9,7 +9,7 @@ import type { UseQueryResult } from '@tanstack/react-query'
 import { useQueryClient } from '@tanstack/react-query'
 import Image from 'next/image'
 import Balancer from 'react-wrap-balancer'
-import parse from 'html-react-parser'
+import parse, { domToReact } from 'html-react-parser'
 import MovieSkeleton from './Skeleton'
 import { useQuery } from '@tanstack/react-query'
 import { getMovieDetails } from '@/utils/getMovieDetails'
@@ -225,7 +225,13 @@ const MovieDetails: FC<MovieDetailProps> = ({ id, sessionData }) => {
       {!!movie?.tomatoRating?.consensus && (
         <div className="flex w-full">
           <Balancer className="mx-auto mb-8 text-xl text-white md:text-3xl xl:text-5xl">
-            {parse(movie.tomatoRating.consensus)}
+            {parse(movie.tomatoRating.consensus, {
+              replace(domNode: any) {
+                if (domNode.type === 'tag' && !['em', 'strong', 'b', 'i'].includes(domNode.name)) {
+                  return <>{domToReact(domNode.children || [])}</>
+                }
+              },
+            })}
           </Balancer>
         </div>
       )}

--- a/src/pages/api/movie/[id].ts
+++ b/src/pages/api/movie/[id].ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { FLIXSTER_API_MOVIE_DETAILS_URL, RAPID_API_HOST } from '@/data/Constants'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query
+  if (!id || typeof id !== 'string') {
+    return res.status(400).json({ error: 'id parameter is required' })
+  }
+
+  const response = await fetch(`${FLIXSTER_API_MOVIE_DETAILS_URL}${id}`, {
+    method: 'GET',
+    headers: {
+      'X-RapidAPI-Key': process.env.RAPID_API_KEY as string,
+      'X-RapidAPI-Host': RAPID_API_HOST,
+    },
+  })
+  const data = await response.json()
+  return res.status(200).json(data)
+}

--- a/src/pages/api/search.ts
+++ b/src/pages/api/search.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { FLIXSTER_API_SEARCH_URL, RAPID_API_HOST } from '@/data/Constants'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { query } = req.query
+  if (!query || typeof query !== 'string') {
+    return res.status(400).json({ error: 'query parameter is required' })
+  }
+
+  const response = await fetch(`${FLIXSTER_API_SEARCH_URL}${encodeURIComponent(query)}`, {
+    method: 'GET',
+    headers: {
+      'X-RapidAPI-Key': process.env.RAPID_API_KEY as string,
+      'X-RapidAPI-Host': RAPID_API_HOST,
+    },
+  })
+  const data = await response.json()
+  return res.status(200).json(data)
+}

--- a/src/server/api/routers/watchListItem.ts
+++ b/src/server/api/routers/watchListItem.ts
@@ -61,7 +61,7 @@ export const watchListItemRouter = createTRPCRouter({
         
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (error:any) {
-        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: error.message })
+        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to save movie to watchlist' })
       }
 
     
@@ -80,11 +80,11 @@ export const watchListItemRouter = createTRPCRouter({
       }
     })
   }),
-  query: publicProcedure.input(z.object({
+  query: protectedProcedure.input(z.object({
     movieId: z.string()
   })).query(async ({ ctx, input }) => {
     const { prisma, session } = ctx;
-    const userIdNum = session?.user?.id;
+    const userIdNum = session.user.id;
     const { movieId } = input;
 
     const movie = await prisma.watchListItem.findMany({

--- a/src/utils/getMovieDetails.ts
+++ b/src/utils/getMovieDetails.ts
@@ -1,15 +1,5 @@
-import { FLIXSTER_API_MOVIE_DETAILS_URL, RAPID_API_HOST } from "@/data/Constants"
-
-const options = {
-  method: 'GET',
-  headers: {
-    'X-RapidAPI-Key': 'd8739849e9msh9de0a072a19f9edp1762cejsne12be3c09936',
-    'X-RapidAPI-Host': RAPID_API_HOST
-	}
-};
-
-export const getMovieDetails = async (id: string) => { 
-  const res = await fetch(`${FLIXSTER_API_MOVIE_DETAILS_URL}${id}`, options)
+export const getMovieDetails = async (id: string) => {
+  const res = await fetch(`/api/movie/${id}`)
   const data = await res.json()
   return data
 }

--- a/src/utils/getSearchMovies.ts
+++ b/src/utils/getSearchMovies.ts
@@ -1,15 +1,5 @@
-import { RAPID_API_HOST, FLIXSTER_API_SEARCH_URL } from "@/data/Constants"
-
-const options = {
-  method: 'GET',
-  headers: {
-    'X-RapidAPI-Key': 'd8739849e9msh9de0a072a19f9edp1762cejsne12be3c09936',
-    'X-RapidAPI-Host': RAPID_API_HOST,
-  },
-}
-
-export const getSearchMovies = async (query: string) => { 
-  const res = await fetch(`${FLIXSTER_API_SEARCH_URL}${query}`, options)
+export const getSearchMovies = async (query: string) => {
+  const res = await fetch(`/api/search?query=${encodeURIComponent(query)}`)
   const data = await res.json()
   return data
 }


### PR DESCRIPTION
## Summary

- **Critical: Exposed API key** — Hardcoded RapidAPI key was being sent to the browser in `getMovieDetails.ts` and `getSearchMovies.ts`. Created server-side proxy routes (`/api/search`, `/api/movie/[id]`) so the key stays on the server; client utilities now call these routes instead.
- **High: XSS vulnerability** — `html-react-parser` was rendering unsanitized HTML from the Flixster API directly into the DOM. Added a tag allowlist (`em`, `strong`, `b`, `i`) so only safe formatting tags are rendered; anything else has its children preserved but the tag stripped.
- **Medium: Unauthenticated watchlist query** — `query` procedure was using `publicProcedure`, allowing unauthenticated requests. Changed to `protectedProcedure` to match `create` and `delete`.
- **Medium: Internal error leakage** — `error.message` was forwarded to the client in the TRPC error, potentially exposing database/Prisma details. Replaced with a generic message.

## Action required

Rotate the exposed RapidAPI key (`d8739849e9msh9de0a072a19f9edp1762cejsne12be3c09936`) — it was hardcoded in git history and is no longer safe to use. Make sure `RAPID_API_KEY` is set in your `.env` and Vercel environment variables.

## Test plan

- [ ] Search still works on the home page
- [ ] Movie detail page still loads correctly
- [ ] Add/remove from watchlist still works when logged in
- [ ] Watchlist query is blocked for unauthenticated users
- [ ] Verify RapidAPI key does not appear in browser network requests or JS source

🤖 Generated with [Claude Code](https://claude.com/claude-code)