### PR TITLE
Visual refresh: hero, richer movie details, polished cards & mobile

### DIFF
--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -1,109 +1,57 @@
-import { useState, useRef, useEffect } from 'react';
-import type { FC } from 'react';
-import type { CarouselProps } from './types';
+import { useState, useRef, useEffect, useCallback } from 'react'
+import type { FC } from 'react'
+import { HiChevronLeft, HiChevronRight } from 'react-icons/hi'
+import type { CarouselProps } from './types'
 
 const Carousel: FC<CarouselProps> = ({ movieCards }) => {
-  const maxScrollWidth = useRef(0);
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const carousel = useRef<HTMLDivElement>(null);
+  const scroller = useRef<HTMLDivElement>(null)
+  const [atStart, setAtStart] = useState(true)
+  const [atEnd, setAtEnd] = useState(false)
 
-  const movePrev = () => {
-    if (currentIndex > 0) {
-      setCurrentIndex((prevState) => prevState - 1);
-    }
-  };
-
-  const moveNext = () => {
-    if (
-      carousel.current !== null &&
-      carousel.current.offsetWidth * currentIndex <= maxScrollWidth.current
-    ) {
-      setCurrentIndex((prevState) => prevState + 1);
-    }
-  };
-
-  const isDisabled = (direction: string) => {
-    if (direction === 'prev') {
-      return currentIndex <= 0;
-    }
-
-    if (direction === 'next' && carousel.current !== null) {
-      return (
-        carousel.current.offsetWidth * currentIndex >= maxScrollWidth.current
-      );
-    }
-
-    return false;
-  };
+  const updateEdges = useCallback(() => {
+    const el = scroller.current
+    if (!el) return
+    setAtStart(el.scrollLeft <= 8)
+    setAtEnd(el.scrollLeft + el.clientWidth >= el.scrollWidth - 8)
+  }, [])
 
   useEffect(() => {
-    if (carousel !== null && carousel.current !== null) {
-      carousel.current.scrollLeft = carousel.current.offsetWidth * currentIndex;
-    }
-  }, [currentIndex]);
+    updateEdges()
+  }, [movieCards, updateEdges])
 
-  useEffect(() => {
-    maxScrollWidth.current = carousel.current
-      ? carousel.current.scrollWidth - carousel.current.offsetWidth
-      : 0;
-  }, []);
+  const scrollByAmount = (direction: number) => {
+    const el = scroller.current
+    if (!el) return
+    el.scrollBy({ left: direction * el.clientWidth * 0.8, behavior: 'smooth' })
+  }
 
   return (
-    <div className="carousel my-6 mx-auto w-10/12 sm:w-11/12 overflow-x-auto">
-      <div className="relative overflow-hidden w-full">
-        <div className="flex justify-between absolute top left w-full h-full">
-          <button
-            onClick={movePrev}
-            className="text-white w-10 h-full text-center opacity-75 hover:opacity-100 disabled:opacity-25 disabled:cursor-not-allowed z-10 p-0 m-0 transition-all ease-in-out duration-300"
-            disabled={isDisabled('prev')}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-12 w-20 -ml-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M15 19l-7-7 7-7"
-              />
-            </svg>
-            <span className="sr-only">Prev</span>
-          </button>
-          <button
-            onClick={moveNext}
-            className="text-white w-10 h-full text-center opacity-75 hover:opacity-100 disabled:opacity-25 disabled:cursor-not-allowed z-10 p-0 m-0 transition-all ease-in-out duration-300"
-            disabled={isDisabled('next')}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-12 w-20 -ml-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M9 5l7 7-7 7"
-              />
-            </svg>
-            <span className="sr-only">Next</span>
-          </button>
-        </div>
-        <div
-          ref={carousel}
-          className="relative flex overflow-x-auto gap-4 sm:gap-0 scroll-smooth snap-x snap-mandatory touch-pan-x z-0 w-full pb-4"
-        >
+    <div className="group relative mx-auto w-full max-w-screen-2xl px-4 sm:px-8">
+      <button
+        onClick={() => scrollByAmount(-1)}
+        aria-label="Scroll left"
+        className="absolute left-3 top-[38%] z-20 hidden -translate-y-1/2 rounded-full bg-black/70 p-2 text-white shadow-lg backdrop-blur transition hover:bg-black/90 disabled:pointer-events-none disabled:opacity-0 sm:group-hover:flex"
+        disabled={atStart}
+      >
+        <HiChevronLeft className="h-7 w-7" />
+      </button>
+      <button
+        onClick={() => scrollByAmount(1)}
+        aria-label="Scroll right"
+        className="absolute right-3 top-[38%] z-20 hidden -translate-y-1/2 rounded-full bg-black/70 p-2 text-white shadow-lg backdrop-blur transition hover:bg-black/90 disabled:pointer-events-none disabled:opacity-0 sm:group-hover:flex"
+        disabled={atEnd}
+      >
+        <HiChevronRight className="h-7 w-7" />
+      </button>
+      <div
+        ref={scroller}
+        onScroll={updateEdges}
+        className="hide-scrollbar edge-fade-x flex snap-x gap-4 overflow-x-auto scroll-smooth pb-2"
+      >
         {movieCards}
-        </div>
       </div>
     </div>
-  );
+  )
 }
 
 export default Carousel

--- a/src/components/CastCard/CastCard.tsx
+++ b/src/components/CastCard/CastCard.tsx
@@ -1,30 +1,32 @@
-import type { FC } from "react"
-import type { CastCardProps } from "./types"
-import Image from "next/image"
-import Balancer from "react-wrap-balancer"
+import type { FC } from 'react'
+import type { CastCardProps } from './types'
+import Image from 'next/image'
 
 const CastCard: FC<CastCardProps> = ({
-  id,
   role,
   name,
   characterName,
   headShotImage,
 }) => {
+  const subtitle = characterName || role
+
   return (
-    <div className="min-w-44 flex max-w-fit flex-col text-white">
-      <div className='min-h-fit'>
+    <div className="w-28 shrink-0 text-center sm:w-full">
+      <div className="relative aspect-[2/3] overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900">
         <Image
           src={headShotImage?.url || '/Default-Avatar.png'}
-          className="z-20 mx-auto mb-2 aspect-auto h-60 rounded object-cover"
-          height={240}
-          width={176}
+          fill
+          sizes="(max-width: 640px) 30vw, 160px"
+          className="object-cover"
           alt={`${name} headshot`}
         />
       </div>
-      <div className="flex h-full flex-col gap-y-1 text-center">
-        {name && <p className="text-lg font-bold">{name}</p>}
-        {characterName && <p>{characterName}</p>}
-      </div>
+      {name && (
+        <p className="mt-2 truncate text-sm font-semibold text-white">{name}</p>
+      )}
+      {subtitle && (
+        <p className="truncate text-xs text-zinc-400">{subtitle}</p>
+      )}
     </div>
   )
 }

--- a/src/components/CastGrid/CastGrid.tsx
+++ b/src/components/CastGrid/CastGrid.tsx
@@ -1,19 +1,19 @@
-import type { FC } from "react"
-import CastCard from "../CastCard/CastCard"
-import type { CastGridProps } from "./types"
+import type { FC } from 'react'
+import CastCard from '../CastCard/CastCard'
+import type { CastGridProps } from './types'
 
-const CastGrid:FC<CastGridProps> = ({ cast }) => {
+const CastGrid: FC<CastGridProps> = ({ cast, title = 'Cast' }) => {
+  if (!cast?.length) return null
   return (
-    <div className="my-12 text-white lg:col-start-1 lg:col-end-5">
-      <>
-        <h3 className="mb-4 text-xl">Cast</h3>
-        <div className="md:grid-credit-cards mx-auto	grid auto-rows-fr grid-cols-2 gap-x-2 gap-y-4 sm:grid-cols-3 2xl:grid-cols-4">
-          {cast.map((castMember) => {
-            return <CastCard key={castMember.id} {...castMember} />
-          })}
-        </div>
-      </>
-    </div>
+    <section className="my-10 text-white">
+      <h3 className="section-heading mb-4">{title}</h3>
+      {/* Horizontal scroll on mobile, grid on larger screens */}
+      <div className="hide-scrollbar edge-fade-x flex gap-4 overflow-x-auto pb-2 sm:grid sm:grid-cols-4 sm:gap-x-4 sm:gap-y-6 sm:overflow-visible lg:grid-cols-6">
+        {cast.map((castMember, idx) => (
+          <CastCard key={`${castMember.id}-${idx}`} {...castMember} />
+        ))}
+      </div>
+    </section>
   )
 }
 

--- a/src/components/CastGrid/types.d.ts
+++ b/src/components/CastGrid/types.d.ts
@@ -1,6 +1,7 @@
 import type { ComponentPropsWithoutRef } from "react";
+import type { Image } from "@/types/main";
 
-export interface Credit { 
+export interface Credit {
   id: string
   role?: string
   name: string
@@ -10,4 +11,5 @@ export interface Credit {
 
 export interface CastGridProps extends ComponentPropsWithoutRef<'div'>{
   cast: Credit[]
+  title?: string
 }

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,11 +1,14 @@
-import Balancer from "react-wrap-balancer"
+import Balancer from 'react-wrap-balancer'
 
 const Footer = () => {
   return (
-    <footer className="w-full pb-4 text-center text-white mt-auto">
-      <Balancer className="text-2xl">
+    <footer className="mt-auto w-full border-t border-zinc-800/80 py-6 text-center text-zinc-400">
+      <Balancer className="text-sm sm:text-base">
         Made with ❤️ by{' '}
-        <a href="https://leonmarbukh.com/" className="underline">
+        <a
+          href="https://leonmarbukh.com/"
+          className="text-zinc-200 underline decoration-pink-500 underline-offset-4 transition hover:text-pink-400"
+        >
           Leon Marbukh
         </a>
       </Balancer>

--- a/src/components/Head.tsx
+++ b/src/components/Head.tsx
@@ -1,15 +1,37 @@
-import NextHead from "next/head"
-import type { FC } from "react"
+import NextHead from 'next/head'
+import type { FC } from 'react'
 
+interface HeadProps {
+  title?: string
+  description?: string
+  image?: string
+}
 
-const Head: FC = () => (
-  <NextHead>
-    <meta charSet="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>Movie Fan</title>
-    <meta name="description" content="Movie Fan App" />
-    <link rel="icon" href="/favicon.ico" />
-  </NextHead>
-)
+const Head: FC<HeadProps> = ({
+  title = 'Movie Fan',
+  description = 'Discover popular, upcoming, and now-playing movies. Build your watchlist and rate what you have seen.',
+  image = '/movie-ticket.png',
+}) => {
+  const fullTitle = title === 'Movie Fan' ? title : `${title} · Movie Fan`
+
+  return (
+    <NextHead>
+      <meta charSet="utf-8" />
+      <meta name="viewport" content="width=device-width,initial-scale=1" />
+      <title>{fullTitle}</title>
+      <meta name="description" content={description} />
+      <meta name="theme-color" content="#000000" />
+      <meta property="og:title" content={fullTitle} />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={image} />
+      <meta property="og:type" content="website" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={fullTitle} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={image} />
+      <link rel="icon" href="/favicon.ico" />
+    </NextHead>
+  )
+}
 
 export default Head

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -1,0 +1,65 @@
+import type { FC } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import type { MovieCardProps } from '@/components/MovieCard/types'
+
+interface HeroProps {
+  movie: MovieCardProps
+}
+
+const Hero: FC<HeroProps> = ({ movie }) => {
+  const poster =
+    (typeof movie.posterImage === 'string'
+      ? movie.posterImage
+      : movie.posterImage?.url) || '/placeholderposter.png'
+  const score = movie.tomatoMeter ?? movie.tomatoRating?.tomatometer ?? null
+
+  return (
+    <section className="relative overflow-hidden">
+      {/* Blurred, darkened poster as an ambient backdrop */}
+      <div className="absolute inset-0">
+        <Image
+          src={poster}
+          fill
+          priority
+          sizes="100vw"
+          alt=""
+          aria-hidden
+          className="scale-110 object-cover blur-2xl brightness-[0.35]"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-black via-black/70 to-transparent" />
+      </div>
+
+      <div className="relative mx-auto flex max-w-screen-xl flex-col items-center gap-6 px-4 py-10 sm:flex-row sm:items-end sm:px-8 sm:py-16">
+        <div className="relative aspect-[2/3] w-36 shrink-0 overflow-hidden rounded-xl border border-zinc-700 shadow-2xl sm:w-52">
+          <Image
+            src={poster}
+            fill
+            priority
+            sizes="(max-width: 640px) 40vw, 210px"
+            alt={`${movie.name} poster`}
+            className="object-cover"
+          />
+        </div>
+        <div className="text-center sm:text-left">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-pink-400">
+            #1 Popular
+          </p>
+          <h2 className="font-heading text-3xl font-bold text-white sm:text-5xl">
+            {movie.name}
+          </h2>
+          {score != null && (
+            <p className="chip mt-4 text-base">🍅 {score}%</p>
+          )}
+          <div className="mt-6">
+            <Link href={`/movie/${movie.emsVersionId}`} className="btn-brand">
+              View details
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default Hero

--- a/src/components/MovieCard/MovieCard.tsx
+++ b/src/components/MovieCard/MovieCard.tsx
@@ -3,28 +3,55 @@ import type { MovieCardProps } from './types'
 import Image from 'next/image'
 import Link from 'next/link'
 
-const MovieCard: FC<MovieCardProps> = ({ name, posterImage, emsVersionId }) => {
+const MovieCard: FC<MovieCardProps> = ({
+  name,
+  posterImage,
+  emsVersionId,
+  releaseDate,
+  tomatoRating,
+  tomatoMeter,
+  userRating,
+}) => {
   // posterImage is a string for watchlist items and an { url } object (whose
   // url may be missing) for API results
   const posterSrc =
     (typeof posterImage === 'string' ? posterImage : posterImage?.url) ||
     '/placeholderposter.png'
 
+  const year = releaseDate ? String(releaseDate).slice(0, 4) : null
+  // tomatoMeter comes from the DB, tomatoRating.tomatometer from the API
+  const score = tomatoMeter ?? tomatoRating?.tomatometer ?? null
+  const stars = typeof userRating === 'number' ? userRating : null
+
   return (
-    <Link href={`/movie/${emsVersionId}`}>
-      <div className="relative flex aspect-[489/725] h-72 max-h-96 max-w-[195] cursor-pointer snap-center flex-col items-center rounded-lg border bg-white sm:mx-4 sm:snap-start">
+    <Link
+      href={`/movie/${emsVersionId}`}
+      className="group block w-36 shrink-0 snap-start sm:w-44"
+    >
+      <div className="relative aspect-[2/3] overflow-hidden rounded-xl border border-zinc-800 bg-zinc-900 shadow-lg transition duration-300 group-hover:border-zinc-600 group-hover:shadow-pink-900/20">
         <Image
-          className="absolute inset-0 z-0 rounded-lg bg-cover bg-center"
+          className="object-cover transition duration-300 group-hover:scale-105"
           src={posterSrc}
           fill
-          sizes="(max-width: 768px) 75vw,
-            (max-width: 1200px) 25vw,
-            20vw"
-          alt="movie poster"
+          sizes="(max-width: 640px) 40vw, 180px"
+          alt={`${name} poster`}
         />
-        <div className="absolute inset-0	 z-10 grid h-full place-items-center items-center  rounded-lg p-4 text-white opacity-0 hover:from-cyan-500 hover:to-blue-500 md:hover:bg-gradient-to-r lg:hover:opacity-90">
-          <h2 className="mb-4 text-center text-3xl">{name}</h2>
-        </div>
+        {score != null && (
+          <span className="absolute left-2 top-2 flex items-center gap-1 rounded-full bg-black/75 px-2 py-0.5 text-xs font-semibold text-white backdrop-blur">
+            🍅 {score}%
+          </span>
+        )}
+        {stars != null && (
+          <span className="absolute right-2 top-2 flex items-center gap-1 rounded-full bg-black/75 px-2 py-0.5 text-xs font-semibold text-yellow-400 backdrop-blur">
+            ★ {stars}
+          </span>
+        )}
+      </div>
+      <div className="mt-2 px-0.5">
+        <p className="truncate font-heading text-sm font-semibold text-white transition group-hover:text-pink-400">
+          {name}
+        </p>
+        {year && <p className="text-xs text-zinc-500">{year}</p>}
       </div>
     </Link>
   )

--- a/src/components/MovieCard/MovieCardSkeleton.tsx
+++ b/src/components/MovieCard/MovieCardSkeleton.tsx
@@ -1,0 +1,9 @@
+const MovieCardSkeleton = () => (
+  <div className="w-36 shrink-0 animate-pulse sm:w-44">
+    <div className="aspect-[2/3] rounded-xl border border-zinc-800 bg-zinc-800/60" />
+    <div className="mt-2 h-3 w-3/4 rounded bg-zinc-800/60" />
+    <div className="mt-1.5 h-2.5 w-1/3 rounded bg-zinc-800/60" />
+  </div>
+)
+
+export default MovieCardSkeleton

--- a/src/components/MovieCard/types.d.ts
+++ b/src/components/MovieCard/types.d.ts
@@ -3,6 +3,12 @@ import type { ComponentPropsWithRef } from 'react';
 
 export interface MovieCardProps extends ComponentPropsWithRef<'div'> {
   name: string;
-  posterImage: Image | string;
+  posterImage: Image | string | null;
   emsVersionId: string;
+  releaseDate?: string | null;
+  // Critic score: an object from the API, a number from the DB watchlist
+  tomatoRating?: { tomatometer?: number | null } | null;
+  tomatoMeter?: number | null;
+  // The signed-in user's own star rating (DB watchlist items only)
+  userRating?: number | null;
 }

--- a/src/components/MovieDetails/MovieDetails.tsx
+++ b/src/components/MovieDetails/MovieDetails.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { FC } from 'react'
 import type { IMovieDetail, MovieDetailProps } from './types'
 import Image from 'next/image'
@@ -11,6 +12,45 @@ import { signIn } from 'next-auth/react'
 import ReactStars from 'react-rating-stars-component'
 import { createMovieObj } from '@/utils/createMovieObj'
 import CastGrid from '../CastGrid/CastGrid'
+
+const formatRuntime = (minutes?: number | null) => {
+  if (!minutes) return null
+  const h = Math.floor(minutes / 60)
+  const m = minutes % 60
+  return h > 0 ? `${h}h ${m}m` : `${m}m`
+}
+
+const ScoreBadge = ({
+  iconUrl,
+  score,
+  count,
+  suffix = '%',
+}: {
+  iconUrl?: string
+  score?: number | null
+  count?: number | null
+  suffix?: string
+}) => {
+  if (score == null) return null
+  return (
+    <div className="flex items-center gap-2">
+      {iconUrl && (
+        <Image src={iconUrl} height={28} width={28} alt="" className="h-7 w-7" />
+      )}
+      <div className="leading-tight">
+        <p className="text-lg font-bold text-white">
+          {score}
+          {suffix}
+        </p>
+        {count ? (
+          <p className="text-xs text-zinc-400">
+            {count.toLocaleString()} ratings
+          </p>
+        ) : null}
+      </div>
+    </div>
+  )
+}
 
 const MovieDetails: FC<MovieDetailProps> = ({ id, sessionData }) => {
   const { data, isLoading, isError } = api.flixster.details.useQuery(
@@ -25,221 +65,302 @@ const MovieDetails: FC<MovieDetailProps> = ({ id, sessionData }) => {
     utils.user.query.invalidate()
   }
 
-  const addMovie = api.movie.create.useMutation({
-    onSuccess: invalidateWatchlist,
-  })
+  const addMovie = api.movie.create.useMutation({ onSuccess: invalidateWatchlist })
   // The query is a protected procedure, so only run it when signed in
   const watchlistItem = api.movie.query.useQuery(
     { movieId: id },
     { enabled: !!sessionData }
   )
-  const removeMovie = api.movie.delete.useMutation({
-    onSuccess: invalidateWatchlist,
-  })
-  // refactor into better error handling
+  const removeMovie = api.movie.delete.useMutation({ onSuccess: invalidateWatchlist })
+
   if (isError) {
     return (
-      <div>
-        <p>Please Let Leon know about this error</p>
-        <p>Email: leonmarbukh@gmail.com</p>
+      <div className="mx-auto max-w-md px-4 py-20 text-center text-white">
+        <p className="mb-2 text-2xl font-bold">Something went wrong</p>
+        <p className="text-zinc-400">
+          Please let Leon know at{' '}
+          <a className="text-pink-400 underline" href="mailto:leonmarbukh@gmail.com">
+            leonmarbukh@gmail.com
+          </a>
+        </p>
       </div>
     )
   }
-  // improve skeleton animation
-  if (isLoading) {
-    return <MovieSkeleton />
-  }
-  const movie = data?.movie
+
+  if (isLoading) return <MovieSkeleton />
+
+  const movie: any = data?.movie
 
   if (!movie) {
     return (
-      <div>
-        <p className="text-center text-4xl text-white ">Movie not found</p>
-      </div>
+      <p className="px-4 py-20 text-center text-4xl text-white">Movie not found</p>
     )
   }
 
-  const genres: string[] = movie.genres.map(
+  const genres: string[] = (movie.genres || []).map(
     (genre: { name: string }) => genre.name
   )
+  const poster = movie.posterImage?.url || '/placeholderposter.png'
+  const backdrop = movie.backgroundImage?.url || poster
+  const year = movie.releaseDate ? String(movie.releaseDate).slice(0, 4) : null
+  const runtime = formatRuntime(movie.durationMinutes)
+  const gallery = (movie.images || []).slice(0, 8)
+  const theaters = movie.showtimeGroupings?.theaters || []
+  const ticketsUrl = `https://www.fandango.com/search?q=${encodeURIComponent(
+    movie.name
+  )}`
 
-  const handleAddMovie = (
-    movie: IMovieDetail,
-    id: string,
-    genres: string[]
-  ) => {
-    const movieData = createMovieObj(movie, id, genres)
-    addMovie.mutate({ movieData })
+  const handleAddMovie = () => {
+    addMovie.mutate({ movieData: createMovieObj(movie as IMovieDetail, id, genres) })
   }
-
-  const handleRemoveMovie = (movieId: string) => {
-    removeMovie.mutate({ movieId })
-  }
-
+  const handleRemoveMovie = () => removeMovie.mutate({ movieId: id })
   // The server upserts on [userId, movieId], so rating a movie is a single
   // mutation whether or not it is already on the watchlist
-  const handleSeenMovie = (
-    movie: IMovieDetail,
-    id: string,
-    genres: string[],
-    userRating: number
-  ) => {
-    const movieData = createMovieObj(movie, id, genres, userRating)
-    addMovie.mutate({ movieData })
+  const handleSeenMovie = (userRating: number) => {
+    addMovie.mutate({
+      movieData: createMovieObj(movie as IMovieDetail, id, genres, userRating),
+    })
   }
-  //if user has reated movied, remove 'remove from watchlist' button
 
+  const onWatchlist = !!watchlistItem.data?.movie.length
+  const currentUserRating = watchlistItem.data?.movie[0]?.userRating || 0
   const starsConfig = {
-    size: 30,
+    size: 32,
     count: 5,
-    value: watchlistItem?.data?.movie[0]?.userRating || 0,
-    onChange: (userRating: number) => {
-      handleSeenMovie(movie, id, genres, userRating)
-    },
+    isHalf: false,
+    value: currentUserRating,
+    activeColor: '#facc15',
+    color: '#3f3f46',
+    onChange: (userRating: number) => handleSeenMovie(userRating),
   }
 
   return (
-    <div className="container mx-auto px-4 pb-20">
-      <div className="container mb-12 grid place-content-start lg:grid-cols-6">
-        <div className="pb-12 text-white lg:col-start-1 lg:col-end-4">
-          <div className="flex flex-col justify-between md:flex-row">
-            <Balancer className="flex pb-2 text-3xl xl:text-5xl">
-              {movie.name}
-            </Balancer>
-            {!!movie.tomatoRating?.iconImage && (
-              <div className="flex w-8 items-center sm:w-24">
-                <Image
-                  src={movie.tomatoRating.iconImage.url as string}
-                  height={50}
-                  width={50}
-                  alt="Movie Backdrop"
-                />
-                <p className="pl-2 text-lg lg:text-3xl">
-                  {movie.tomatoRating.tomatometer}%
-                </p>
-              </div>
-            )}
-          </div>
-          {!!movie.posterImage && (
-            <div className="my-4 flex content-center lg:hidden">
-              <Image
-                src={movie.posterImage.url}
-                height={300}
-                width={450}
-                priority
-                alt="Movie Backdrop"
-              />
-            </div>
-          )}
-          <div className="sm:pt-0pb-4 flex pt-2 align-middle">
-            <p className="pr-4 text-lg xl:text-xl">
-              {movie.releaseDate.slice(0, 4)}
-            </p>
-            <p className="text-lg xl:text-xl">Directed By {movie.directedBy}</p>
-          </div>
-          <div></div>
-          <p className="pb-4">{movie.synopsis}</p>
-          <div className="mb-2 flex flex-col sm:flex-row">
-            {movie.durationMinutes && (
-              <p className="mr-4">{movie.durationMinutes} minutes</p>
-            )}
-            <div className="flex">
-              {genres.slice(0, 3).map((genre: string, idx: number) => (
-                <p key={idx} className="mx-2 first:ml-0 sm:first:ml-2">
-                  {genre}
-                </p>
-              ))}
-            </div>
-            {!!movie.motionPictureRating && (
-              <p className="mr-2 sm:ml-auto">
-                Rated: {movie.motionPictureRating.code}
-              </p>
-            )}
-          </div>
-          <div className="my-8 flex h-20 flex-col items-baseline	sm:flex-row sm:items-end sm:justify-between">
-            {!!watchlistItem.data?.movie.length ? (
-              <>
-                <ReactStars {...starsConfig} />
-                {!watchlistItem.data.movie[0]?.userRating && (
-                  <button
-                    className="
-                    bordered
-                    mt-8
-                    rounded
-                    bg-red-500
-                    py-2
-                    px-4
-                    font-heading
-                    text-xl
-                    text-white
-                    hover:bg-red-700"
-                    onClick={() => handleRemoveMovie(id)}
-                  >
-                    Remove From Watchlist
-                  </button>
-                )}
-              </>
-            ) : (
-              <>
-                {sessionData && <ReactStars {...starsConfig} />}
-                <button
-                  className="bordered mt-8 rounded bg-blue-500 py-2 px-4 font-heading text-xl text-white hover:bg-blue-600"
-                  onClick={
-                    sessionData
-                      ? () => handleAddMovie(movie, id, genres)
-                      : () => signIn()
-                  }
-                >
-                  {sessionData ? (
-                    <Balancer>{'Add to Watchlist'}</Balancer>
-                  ) : (
-                    <Balancer>
-                      {'Sign in to Add to Watchlist/Rate Movie'
-                  }</Balancer>
-                  )}
-                </button>
-              </>
-            )}
-          </div>
-          {!!movie.cast && <CastGrid cast={movie.cast} />}
+    <article className="pb-24 text-white">
+      {/* Backdrop hero */}
+      <div className="relative">
+        <div className="absolute inset-0 overflow-hidden">
+          <Image
+            src={backdrop}
+            fill
+            priority
+            sizes="100vw"
+            alt=""
+            aria-hidden
+            className="object-cover object-top brightness-[0.3] blur-sm"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-black via-black/80 to-black/40" />
         </div>
-        {!!movie.posterImage && (
-          <div className="hidden lg:col-start-5 lg:col-end-7 lg:inline">
+
+        <div className="relative mx-auto flex max-w-screen-xl flex-col gap-8 px-4 py-8 sm:flex-row sm:px-8 sm:py-12">
+          {/* Poster */}
+          <div className="relative mx-auto aspect-[2/3] w-44 shrink-0 overflow-hidden rounded-xl border border-zinc-700 shadow-2xl sm:mx-0 sm:w-60">
             <Image
-              src={movie.posterImage.url}
-              height={300}
-              width={450}
+              src={poster}
+              fill
               priority
-              alt="Movie Backdrop"
+              sizes="(max-width: 640px) 45vw, 240px"
+              alt={`${movie.name} poster`}
+              className="object-cover"
             />
           </div>
+
+          {/* Meta */}
+          <div className="flex-1">
+            <h1 className="font-heading text-3xl font-bold sm:text-5xl">
+              <Balancer>{movie.name}</Balancer>
+            </h1>
+
+            {/* Fact chips */}
+            <div className="mt-4 flex flex-wrap items-center gap-2">
+              {year && <span className="chip">{year}</span>}
+              {runtime && <span className="chip">{runtime}</span>}
+              {movie.motionPictureRating?.code && (
+                <span
+                  className="chip"
+                  title={movie.motionPictureRating.description || undefined}
+                >
+                  {movie.motionPictureRating.code}
+                </span>
+              )}
+              {movie.availabilityWindow && (
+                <span className="chip border-pink-700/60 bg-pink-950/40 text-pink-200">
+                  {movie.availabilityWindow}
+                </span>
+              )}
+            </div>
+
+            {/* Genres */}
+            {genres.length > 0 && (
+              <div className="mt-3 flex flex-wrap gap-2">
+                {genres.map((genre) => (
+                  <span
+                    key={genre}
+                    className="rounded-full bg-zinc-800/80 px-3 py-1 text-sm text-zinc-300"
+                  >
+                    {genre}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {/* Scores */}
+            <div className="mt-5 flex flex-wrap items-center gap-6">
+              <ScoreBadge
+                iconUrl={movie.tomatoRating?.iconImage?.url}
+                score={movie.tomatoRating?.tomatometer}
+                count={movie.tomatoRating?.ratingCount}
+              />
+              <ScoreBadge
+                iconUrl={movie.userRating?.iconImage?.url}
+                score={movie.userRating?.dtlLikedScore}
+                count={movie.userRating?.ratingCount}
+              />
+            </div>
+
+            {movie.directedBy && (
+              <p className="mt-5 text-zinc-300">
+                <span className="text-zinc-500">Directed by</span>{' '}
+                {movie.directedBy}
+              </p>
+            )}
+
+            {movie.synopsis && (
+              <p className="mt-3 max-w-2xl leading-relaxed text-zinc-200">
+                {movie.synopsis}
+              </p>
+            )}
+
+            {/* Watchlist / rating actions */}
+            <div className="mt-8">
+              {!sessionData ? (
+                <button className="btn-brand" onClick={() => signIn()}>
+                  Sign in to add to watchlist &amp; rate
+                </button>
+              ) : (
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+                  <div className="flex items-center gap-3">
+                    <span className="text-sm text-zinc-400">Your rating:</span>
+                    <ReactStars key={currentUserRating} {...starsConfig} />
+                  </div>
+                  {onWatchlist ? (
+                    <button className="btn-ghost" onClick={handleRemoveMovie}>
+                      Remove from watchlist
+                    </button>
+                  ) : (
+                    <button className="btn-brand" onClick={handleAddMovie}>
+                      + Add to watchlist
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-screen-xl px-4 sm:px-8">
+        {/* Critics' consensus */}
+        {movie.tomatoRating?.consensus && (
+          <blockquote className="surface my-8 border-l-4 border-pink-500 p-5 text-lg italic text-zinc-200 md:text-xl">
+            <Balancer>
+              {parse(movie.tomatoRating.consensus, {
+                replace(domNode: any) {
+                  if (
+                    domNode.type === 'tag' &&
+                    !['em', 'strong', 'b', 'i'].includes(domNode.name)
+                  ) {
+                    return <>{domToReact(domNode.children || [])}</>
+                  }
+                },
+              })}
+            </Balancer>
+          </blockquote>
+        )}
+
+        {/* Trailer */}
+        {movie.trailer?.url && (
+          <section className="my-10">
+            <h3 className="section-heading mb-4">Trailer</h3>
+            <video
+              controls
+              poster={backdrop}
+              className="aspect-video w-full rounded-xl border border-zinc-800 bg-black"
+            >
+              <source src={movie.trailer.url} type="video/mp4" />
+            </video>
+          </section>
+        )}
+
+        {/* Photo gallery */}
+        {gallery.length > 0 && (
+          <section className="my-10">
+            <h3 className="section-heading mb-4">Photos</h3>
+            <div className="hide-scrollbar edge-fade-x flex gap-4 overflow-x-auto pb-2">
+              {gallery.map((img: any, idx: number) => (
+                <div
+                  key={idx}
+                  className="relative aspect-video h-40 shrink-0 overflow-hidden rounded-lg border border-zinc-800 sm:h-52"
+                >
+                  <Image
+                    src={img.url}
+                    fill
+                    sizes="360px"
+                    alt={`${movie.name} still ${idx + 1}`}
+                    className="object-cover"
+                  />
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Cast & crew */}
+        {movie.cast && <CastGrid cast={movie.cast} title="Cast" />}
+        {movie.crew && <CastGrid cast={movie.crew} title="Crew" />}
+
+        {/* Where to watch */}
+        {theaters.length > 0 && (
+          <section className="my-10">
+            <h3 className="section-heading mb-4">Where to watch</h3>
+            <div className="surface flex flex-col gap-4 p-5 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-zinc-300">
+                Playing in{' '}
+                <span className="font-semibold text-white">
+                  {theaters.length}
+                </span>{' '}
+                {theaters.length === 1 ? 'theater' : 'theaters'} near you
+              </p>
+              <a
+                href={ticketsUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="btn-brand"
+              >
+                Get tickets on Fandango
+              </a>
+            </div>
+          </section>
         )}
       </div>
-      {!!movie?.tomatoRating?.consensus && (
-        <div className="flex w-full">
-          <Balancer className="mx-auto mb-8 text-xl text-white md:text-3xl xl:text-5xl">
-            {parse(movie.tomatoRating.consensus, {
-              replace(domNode: any) {
-                if (domNode.type === 'tag' && !['em', 'strong', 'b', 'i'].includes(domNode.name)) {
-                  return <>{domToReact(domNode.children || [])}</>
-                }
-              },
-            })}
-          </Balancer>
-        </div>
-      )}
-      {!!movie.trailer?.url && (
-        <video
-          width={1000}
-          height={500}
-          controls
-          poster="/trailer_placeholder.webp"
-          className="mx-auto"
-        >
-          <source src={movie.trailer.url} type="video/mp4" />
-        </video>
-      )}
-    </div>
+
+      {/* Sticky mobile action bar — keeps the primary action reachable while
+          scrolling through cast, photos, and showtimes */}
+      <div className="fixed inset-x-0 bottom-0 z-40 border-t border-zinc-800 bg-black/90 p-3 backdrop-blur sm:hidden">
+        {!sessionData ? (
+          <button className="btn-brand w-full" onClick={() => signIn()}>
+            Sign in to add &amp; rate
+          </button>
+        ) : onWatchlist ? (
+          <button className="btn-ghost w-full" onClick={handleRemoveMovie}>
+            Remove from watchlist
+          </button>
+        ) : (
+          <button className="btn-brand w-full" onClick={handleAddMovie}>
+            + Add to watchlist
+          </button>
+        )}
+      </div>
+    </article>
   )
 }
 

--- a/src/components/MovieDetails/Skeleton.tsx
+++ b/src/components/MovieDetails/Skeleton.tsx
@@ -1,32 +1,34 @@
-const MovieSkeleton = () => { 
+const MovieSkeleton = () => {
   return (
-    <div
-      role="status"
-      className="container mx-auto px-4 animate-pulse space-y-8 md:flex md:items-center md:space-y-0 md:space-x-8"
-    >
-      <div className="w-full">
-        <div className="mb-4 h-2.5 w-48 rounded-full bg-gray-200 dark:bg-gray-700"></div>
-        <div className="mb-2.5 h-2 max-w-[480px] rounded-full bg-gray-200 dark:bg-gray-700"></div>
-        <div className="mb-2.5 h-2 rounded-full bg-gray-200 dark:bg-gray-700"></div>
-        <div className="mb-2.5 h-2 max-w-[440px] rounded-full bg-gray-200 dark:bg-gray-700"></div>
-        <div className="mb-2.5 h-2 max-w-[460px] rounded-full bg-gray-200 dark:bg-gray-700"></div>
-        <div className="h-2 max-w-[360px] rounded-full bg-gray-200 dark:bg-gray-700"></div>
+    <div role="status" className="animate-pulse">
+      <div className="relative">
+        <div className="mx-auto flex max-w-screen-xl flex-col gap-8 px-4 py-8 sm:flex-row sm:px-8">
+          {/* Poster */}
+          <div className="mx-auto aspect-[2/3] w-48 shrink-0 rounded-xl bg-zinc-800/70 sm:mx-0 sm:w-60" />
+          {/* Meta */}
+          <div className="flex-1 space-y-4">
+            <div className="h-9 w-3/4 rounded bg-zinc-800/70" />
+            <div className="flex gap-2">
+              <div className="h-7 w-16 rounded-full bg-zinc-800/70" />
+              <div className="h-7 w-20 rounded-full bg-zinc-800/70" />
+              <div className="h-7 w-14 rounded-full bg-zinc-800/70" />
+            </div>
+            <div className="flex gap-4">
+              <div className="h-10 w-24 rounded bg-zinc-800/70" />
+              <div className="h-10 w-24 rounded bg-zinc-800/70" />
+            </div>
+            <div className="space-y-2 pt-2">
+              <div className="h-3 w-full rounded bg-zinc-800/70" />
+              <div className="h-3 w-11/12 rounded bg-zinc-800/70" />
+              <div className="h-3 w-4/5 rounded bg-zinc-800/70" />
+            </div>
+            <div className="h-12 w-48 rounded-full bg-zinc-800/70" />
+          </div>
+        </div>
       </div>
-      <div className="flex h-48 w-full items-center justify-center rounded bg-gray-300 dark:bg-gray-700 sm:w-96">
-        <svg
-          className="h-12 w-12 text-gray-200"
-          xmlns="http://www.w3.org/2000/svg"
-          aria-hidden="true"
-          fill="currentColor"
-          viewBox="0 0 640 512"
-        >
-          <path d="M480 80C480 35.82 515.8 0 560 0C604.2 0 640 35.82 640 80C640 124.2 604.2 160 560 160C515.8 160 480 124.2 480 80zM0 456.1C0 445.6 2.964 435.3 8.551 426.4L225.3 81.01C231.9 70.42 243.5 64 256 64C268.5 64 280.1 70.42 286.8 81.01L412.7 281.7L460.9 202.7C464.1 196.1 472.2 192 480 192C487.8 192 495 196.1 499.1 202.7L631.1 419.1C636.9 428.6 640 439.7 640 450.9C640 484.6 612.6 512 578.9 512H55.91C25.03 512 .0006 486.1 .0006 456.1L0 456.1z" />
-        </svg>
-      </div>
-      <span className="sr-only">Loading...</span>
+      <span className="sr-only">Loading…</span>
     </div>
   )
-
 }
 
 export default MovieSkeleton

--- a/src/components/MovieGrid/MovieGrid.tsx
+++ b/src/components/MovieGrid/MovieGrid.tsx
@@ -3,7 +3,7 @@ import type { MovieGridProps } from './types'
 
 const MovieGrid: FC<MovieGridProps> = ({ movieCards }) => {
   return (
-    <div className="my-6 mx-auto grid grid-cards justify-center gap-y-12">
+    <div className="mx-auto flex w-full max-w-screen-xl flex-wrap justify-center gap-x-4 gap-y-8">
       {movieCards}
     </div>
   )

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -6,53 +6,46 @@ import { useRouter } from 'next/router'
 
 const Nav: FC = () => {
   const router = useRouter()
-  const profilePage = router.pathname === '/profile'
+  const onProfilePage = router.pathname === '/profile'
   const { data: sessionData } = useSession()
 
   return (
-    <nav className="h-18 relative flex w-full items-center justify-between bg-black p-8">
+    <nav className="sticky top-0 z-50 flex w-full items-center justify-between border-b border-zinc-800/80 bg-black/70 px-4 py-4 backdrop-blur-md sm:px-8">
       <Link href="/">
-        <h1 className="bg-gradient-to-br from-pink-400 to-red-600 bg-clip-text font-heading text-4xl font-extrabold text-transparent sm:text-5xl lg:text-6xl">
+        <h1 className="gradient-text font-heading text-3xl font-extrabold sm:text-4xl lg:text-5xl">
           Movie Fan
         </h1>
       </Link>
-      <div className="flex gap-8">
-        {sessionData && profilePage ? (
-          <button
-            className="text-md bordered rounded bg-blue-500 py-2 px-4 font-heading text-white hover:bg-blue-600 sm:text-xl"
-            onClick={() => signOut({ callbackUrl: '/' })}
-          >
-            Sign Out
+      <div className="flex items-center gap-4">
+        {sessionData ? (
+          <>
+            {onProfilePage ? (
+              <button className="btn-ghost" onClick={() => signOut({ callbackUrl: '/' })}>
+                Sign Out
+              </button>
+            ) : (
+              <Link
+                href="/profile"
+                className="rounded-full ring-2 ring-transparent transition hover:ring-pink-500"
+                aria-label="Go to your profile"
+              >
+                <Image
+                  src={sessionData.user?.image || '/avatar.png'}
+                  width={48}
+                  height={48}
+                  alt="Your profile avatar"
+                  className="h-12 w-12 rounded-full object-cover"
+                />
+              </Link>
+            )}
+          </>
+        ) : (
+          <button className="btn-brand" onClick={() => signIn()}>
+            Sign in
           </button>
-        ) : sessionData ? (
-          <Link href="/profile">
-            <Image
-              src={sessionData?.user?.image || '/avatar.png'}
-              width={70}
-              height={70}
-              alt="profile avatar"
-              className="h-18 w-18 rounded-full"
-            />
-          </Link>
-        ) : null}
-        {!sessionData && <AuthShowcase />}
+        )}
       </div>
     </nav>
-  )
-}
-
-const AuthShowcase: React.FC = () => {
-  const { data: sessionData } = useSession()
-
-  return (
-    <div className="flex flex-col items-center justify-center gap-4">
-      <button
-        className="text-md bordered rounded bg-blue-500 py-2 px-4 font-heading text-white hover:bg-blue-600 sm:text-xl"
-        onClick={sessionData ? () => signOut() : () => signIn()}
-      >
-        {sessionData ? 'Sign out' : 'Sign in'}
-      </button>
-    </div>
   )
 }
 

--- a/src/components/News/News.tsx
+++ b/src/components/News/News.tsx
@@ -7,53 +7,61 @@ import parse from 'html-react-parser'
 import Balancer from 'react-wrap-balancer'
 
 const News: FC<NewsStoryProps> = ({ newsStories }) => {
-  if (!newsStories) return null
-
-  let news = newsStories.filter(
-    (story) => !story.title.toLowerCase()?.includes('tv' || 'television')
+  const stories = (newsStories || []).filter(
+    (story) => !story.title?.toLowerCase().includes('tv')
   )
-  const mainStory = news.find((story) => story.mainImage.url)
-  news = news.filter((story) => mainStory.id !== story.id)
+  const mainStory = stories.find((story) => story.mainImage?.url)
+  const restStories = stories
+    .filter((story) => story.id !== mainStory?.id)
+    .slice(0, 8)
+
+  // Nothing to show (the news feed is sometimes empty) — render nothing
+  // rather than a stray heading
+  if (stories.length === 0) return null
 
   return (
-    <section className="mx-auto text-white w-11/12 md:w-full md:pl-8">
-      <>
-        <h2 className="mb-4 self-start text-3xl md:text-5xl">News</h2>
-        <div className="sm:w-11/12 space-between grid grid-cols-1 xl:grid-cols-2">
-          {mainStory?.mainImage.url && (
-            <div className="col-span-full flex text-center xl:col-start-2">
-              <a href={mainStory.link} target="_blank" rel="noreferrer">
-                <Image
-                  src={mainStory?.mainImage.url}
-                  height={1200}
-                  width={1200}
-                  priority
-                  alt="news story"
-                />
-                <Balancer className="my-4 text-center text-2xl lg:text-3xl">
-                  {parse( mainStory.title )}
-                </Balancer>
-              </a>
+    <section className="mx-auto w-full max-w-screen-xl px-4 py-6 text-white sm:px-8">
+      <h2 className="section-heading mb-4">
+        <span className="gradient-text">News</span>
+      </h2>
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {mainStory?.mainImage?.url && (
+          <a
+            href={mainStory.link}
+            target="_blank"
+            rel="noreferrer"
+            className="surface group block overflow-hidden"
+          >
+            <div className="relative aspect-video w-full overflow-hidden">
+              <Image
+                src={mainStory.mainImage.url}
+                fill
+                priority
+                sizes="(max-width: 1024px) 100vw, 600px"
+                alt="Featured news story"
+                className="object-cover transition duration-300 group-hover:scale-105"
+              />
             </div>
-          )}
-          <div className="col-span-full	flex flex-col mx-1 xl:ml-12 xl:col-end-2 xl:row-start-1 w-fit">
-            {news.slice(0, 10).map((story: NewStory) => {
-              return (
-                <Balancer key={story.id} className='my-2'>
-                  <a
-                    className="text-lg lg:text-xl hover:text-blue-400"
-                    href={story.link}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    {parse(story.title)}
-                  </a>
-                </Balancer>
-              )
-            })}
-          </div>
-        </div>
-      </>
+            <Balancer className="block p-4 text-lg font-semibold transition group-hover:text-pink-400 lg:text-xl">
+              {parse(mainStory.title)}
+            </Balancer>
+          </a>
+        )}
+        <ul className="surface flex flex-col divide-y divide-zinc-800">
+          {restStories.map((story: NewStory) => (
+            <li key={story.id}>
+              <a
+                className="block px-4 py-3 text-base transition hover:bg-zinc-800/60 hover:text-pink-400 lg:text-lg"
+                href={story.link}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <Balancer>{parse(story.title)}</Balancer>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
     </section>
   )
 }

--- a/src/components/ProfileCard/ProfileCard.tsx
+++ b/src/components/ProfileCard/ProfileCard.tsx
@@ -1,38 +1,34 @@
-import type { FC } from "react"
-import type { ProfileCardProps } from "./types"
-import Image from "next/image"
+import type { FC } from 'react'
+import type { ProfileCardProps } from './types'
+import Image from 'next/image'
 
-const ProfileCard:FC<ProfileCardProps> = ({ user, rated, watchList }) => {
+const ProfileCard: FC<ProfileCardProps> = ({ user, rated, watchList }) => {
   return (
-    <div className="mx-auto my-8 flex justify-center gap-8">
+    <div className="surface mx-auto my-8 flex max-w-2xl flex-col items-center gap-6 p-6 sm:flex-row sm:gap-8">
       <Image
-        className="h-24 w-24 rounded-full sm:h-48 sm:w-48"
+        className="h-24 w-24 rounded-full object-cover ring-2 ring-pink-500/50 sm:h-32 sm:w-32"
         src={user?.image || '/avatar.png'}
-        width={150}
-        height={150}
-        alt={'Profile avatar'}
+        width={128}
+        height={128}
+        alt="Profile avatar"
       />
-      <div className="flex flex-col justify-center gap-y-2">
-        <h1 className="mb-2 text-2xl font-bold text-white underline	underline-offset-8">
-          {user?.name} Profile
+      <div className="flex flex-col items-center gap-3 sm:items-start">
+        <h1 className="text-2xl font-bold text-white">
+          {user?.name || 'Movie Fan'}
         </h1>
-        <div className="flex items-center gap-x-4">
-          <Image
-            src={'/popcorn.png'}
-            width={35}
-            height={35}
-            alt={'Movie Ticket icon'}
-          />
-          <p className="text-white">{rated?.length} movies rated</p>
-        </div>
-        <div className="flex items-center gap-x-4">
-          <Image
-            src={'/movie-ticket.png'}
-            width={35}
-            height={35}
-            alt={'Movie Ticket icon'}
-          />
-          <p className="text-white">{watchList?.length} movies in watchlist</p>
+        <div className="flex gap-3">
+          <div className="flex items-center gap-2 rounded-full bg-zinc-800/80 px-4 py-2">
+            <Image src="/popcorn.png" width={22} height={22} alt="" />
+            <span className="text-white">
+              <span className="font-bold">{rated?.length ?? 0}</span> rated
+            </span>
+          </div>
+          <div className="flex items-center gap-2 rounded-full bg-zinc-800/80 px-4 py-2">
+            <Image src="/movie-ticket.png" width={22} height={22} alt="" />
+            <span className="text-white">
+              <span className="font-bold">{watchList?.length ?? 0}</span> to watch
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,31 +1,58 @@
+import { useRef, useState } from 'react'
 import type { FC } from 'react'
 import type { SearchProps } from './types'
+import { HiOutlineSearch, HiX } from 'react-icons/hi'
+import { CgSpinner } from 'react-icons/cg'
 
-const Search: FC<SearchProps> = ({ loading, handleSearch }) => {
+const Search: FC<SearchProps> = ({ loading, onQueryChange }) => {
+  const [value, setValue] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const handleChange = (next: string) => {
+    setValue(next)
+    onQueryChange(next)
+  }
+
+  const clear = () => {
+    setValue('')
+    onQueryChange('')
+    inputRef.current?.focus()
+  }
+
   return (
-    <>
+    <div className="relative mx-auto w-full max-w-2xl">
+      <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-zinc-400">
+        <HiOutlineSearch className="h-5 w-5" />
+      </span>
       <label className="sr-only" htmlFor="search">
-        Search For Movies
+        Search for movies
       </label>
       <input
-        className={`mx-auto my-6 max-h-14 min-w-[200px] max-w-[800px] cursor-pointer rounded py-2 pl-6 pr-6 pt-2 text-2xl xl:text-3xl ${
-          loading
-            ? 'animate-border bg-white bg-gradient-to-r from-teal-500 via-purple-500 to-pink-500 text-white  transition'
-            : ''
-        }
-        `}
-        onChange={(e) => handleSearch(e)}
+        ref={inputRef}
+        className="w-full rounded-full border border-zinc-700 bg-zinc-900/80 py-3 pl-12 pr-12 text-lg text-white placeholder-zinc-500 shadow-lg outline-none transition focus:border-pink-500 focus:ring-2 focus:ring-pink-500/40"
+        value={value}
+        onChange={(e) => handleChange(e.target.value)}
         id="search"
-        placeholder="Search for Movies"
+        placeholder="Search for movies"
         type="search"
+        autoComplete="off"
       />
-      <a className="clear" id="clearQuery" href="#">
-        <img
-          src="data:image/gif;base64,R0lGODlhAQABAID%2FAMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw%3D%3D"
-          alt=""
-        />
-      </a>
-    </>
+      <span className="absolute right-4 top-1/2 -translate-y-1/2">
+        {loading ? (
+          <CgSpinner className="h-5 w-5 animate-spin text-pink-500" />
+        ) : (
+          value && (
+            <button
+              onClick={clear}
+              aria-label="Clear search"
+              className="text-zinc-400 transition hover:text-white"
+            >
+              <HiX className="h-5 w-5" />
+            </button>
+          )
+        )}
+      </span>
+    </div>
   )
 }
 

--- a/src/components/Search/types.d.ts
+++ b/src/components/Search/types.d.ts
@@ -1,6 +1,4 @@
-import type { ComponentPropsWithRef } from "react";
-
-export interface SearchProps extends ComponentPropsWithRef<'input'>{ 
-  handleSearch: (e: React.ChangeEvent<HTMLInputElement>) => void;
+export interface SearchProps {
+  onQueryChange: (value: string) => void;
   loading: boolean;
 }

--- a/src/components/SearchResults/SearchResults.tsx
+++ b/src/components/SearchResults/SearchResults.tsx
@@ -1,10 +1,13 @@
-import type { FC } from 'react'
-import type { SearchResultsProps } from './types'
+import type { FC, ReactNode } from 'react'
 
-const SearchResults:FC<SearchResultsProps> = ({ movieCards }) => {
+interface SearchResultsProps {
+  children: ReactNode
+}
+
+const SearchResults: FC<SearchResultsProps> = ({ children }) => {
   return (
-    <div className='flex my-6 mx-auto w-full sm:w-11/12 justify-evenly flex-wrap	gap-8'>
-      {movieCards}
+    <div className="mx-auto flex w-full max-w-screen-xl flex-wrap justify-center gap-x-4 gap-y-8 px-4 sm:px-8">
+      {children}
     </div>
   )
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,11 +3,12 @@ import type { GetStaticProps } from 'next'
 import type { NextPage } from 'next'
 import type { HomePageProps } from '@/types/main'
 import type { MovieCardProps } from '@/components/MovieCard/types'
-import type { ChangeEvent } from 'react'
 
 import Layout from '@layout/default'
 import MovieCard from '@/components/MovieCard/MovieCard'
+import MovieCardSkeleton from '@/components/MovieCard/MovieCardSkeleton'
 import Carousel from '@/components/Carousel/Carousel'
+import Hero from '@/components/Hero/Hero'
 import Search from '@/components/Search/Search'
 import News from '@/components/News/News'
 import SearchResults from '@/components/SearchResults/SearchResults'
@@ -18,104 +19,128 @@ import { getPopularMovies } from '@/utils/getPopularMovies'
 import debounce from '@/utils/debounce'
 import { getNews } from '@/utils/getNews'
 
+const MovieRow = ({
+  title,
+  movies,
+}: {
+  title: string
+  movies: MovieCardProps[]
+}) => {
+  if (!movies?.length) return null
+  return (
+    <section className="py-4">
+      <h2 className="section-heading mx-auto max-w-screen-2xl px-4 pb-3 sm:px-8">
+        <span className="gradient-text">{title}</span>
+      </h2>
+      <Carousel
+        movieCards={movies.map((movie) => (
+          <MovieCard key={movie.emsVersionId} {...movie} />
+        ))}
+      />
+    </section>
+  )
+}
+
 const Home: NextPage<HomePageProps> = ({ data }) => {
   const [query, setQuery] = useState('')
   const { popularMovies, upcomingMovies, newsStories } = data
-  const {
-    data: { opening: moviesOpening, popularity: moviesPopular },
-  } = popularMovies
-  const {
-    data: { upcoming: upComingMovies },
-  } = upcomingMovies
+  const moviesPopular = popularMovies.data.popularity || []
+  const moviesOpening = popularMovies.data.opening || []
+  const upComingMovies = upcomingMovies.data.upcoming || []
 
   // React Query keys the request on the debounced query, so stale responses
   // can't overwrite newer ones and errors don't escape as unhandled rejections
   const searchQuery = api.flixster.search.useQuery(
     { query },
-    // retry is capped so a failing search doesn't burn RapidAPI quota
     { enabled: query.length > 0, keepPreviousData: true, retry: 1 }
   )
 
   const debouncedSetQuery = useRef(
-    debounce((value: string) => setQuery(value.trim()), 750)
+    debounce((value: string) => setQuery(value), 500)
   ).current
 
-  const handleSearch = (e: ChangeEvent<HTMLInputElement>) => {
-    debouncedSetQuery(e.target.value)
+  const handleQueryChange = (value: string) => {
+    const trimmed = value.trim()
+    if (trimmed === '') {
+      // Clear instantly; cancel any pending debounced update
+      debouncedSetQuery.cancel()
+      setQuery('')
+    } else {
+      debouncedSetQuery(trimmed)
+    }
   }
 
-  const searchedMovies: MovieCardProps[] =
-    (query && searchQuery.data?.movies) || []
-  const noResultsFound =
-    query.length > 0 && searchQuery.isSuccess && searchedMovies.length === 0
-
-  const popularMovieCards =
-    moviesPopular?.map((movie, idx) => {
-      return <MovieCard key={idx} {...movie} />
-    }) || []
-
-  const openingMovieCards =
-    moviesOpening?.map((movie, idx) => {
-      return <MovieCard key={idx} {...movie} />
-    }) || []
-
-  const upcomingMovieCards =
-    upComingMovies?.map((movie, idx) => {
-      return <MovieCard key={idx} {...movie} />
-    }) || []
-
-  const searchedMovieCards = searchedMovies.map((movie, idx) => {
-    return <MovieCard key={idx} {...movie} />
-  })
+  const isSearching = query.length > 0
+  const results: MovieCardProps[] = searchQuery.data?.movies || []
+  const showSkeletons = isSearching && searchQuery.isLoading
+  const noResults = isSearching && searchQuery.isSuccess && results.length === 0
+  const featured = moviesPopular[0]
 
   return (
     <Layout>
-      <main className="grid items-center">
-        <div className="mx-auto flex flex-col justify-between">
+      <main className="pb-10">
+        {!isSearching && featured && <Hero movie={featured} />}
+
+        <div className="px-4 py-6 sm:px-8">
           <Search
             loading={searchQuery.isFetching}
-            handleSearch={handleSearch}
+            onQueryChange={handleQueryChange}
           />
-          {noResultsFound && (
-            <p className="text-center text-2xl text-white">No results found</p>
-          )}
-          {searchQuery.isError && (
-            <p className="text-center text-2xl text-white">
-              Something went wrong searching, please try again
-            </p>
-          )}
-          <div className={searchedMovieCards.length ? 'hidden' : ''}>
-            <News newsStories={newsStories} />
-          </div>
         </div>
-        {searchedMovieCards.length > 0 ? (
-          <SearchResults movieCards={searchedMovieCards} />
+
+        {isSearching ? (
+          <section>
+            <h2 className="section-heading mx-auto max-w-screen-xl px-4 pb-4 sm:px-8">
+              {searchQuery.isSuccess && !noResults ? (
+                <>
+                  Results for{' '}
+                  <span className="gradient-text">&ldquo;{query}&rdquo;</span>{' '}
+                  <span className="text-lg font-normal text-zinc-500">
+                    ({results.length})
+                  </span>
+                </>
+              ) : (
+                <>
+                  Searching{' '}
+                  <span className="gradient-text">&ldquo;{query}&rdquo;</span>
+                </>
+              )}
+            </h2>
+
+            {searchQuery.isError && (
+              <p className="py-10 text-center text-xl text-zinc-300">
+                Something went wrong searching. Please try again.
+              </p>
+            )}
+
+            {noResults && (
+              <p className="py-10 text-center text-xl text-zinc-300">
+                No movies found for &ldquo;{query}&rdquo;.
+              </p>
+            )}
+
+            {showSkeletons && (
+              <SearchResults>
+                {Array.from({ length: 10 }).map((_, idx) => (
+                  <MovieCardSkeleton key={idx} />
+                ))}
+              </SearchResults>
+            )}
+
+            {!showSkeletons && results.length > 0 && (
+              <SearchResults>
+                {results.map((movie) => (
+                  <MovieCard key={movie.emsVersionId} {...movie} />
+                ))}
+              </SearchResults>
+            )}
+          </section>
         ) : (
           <>
-            {!!popularMovieCards.length && (
-              <>
-                <h2 className="pl-8 pt-2 text-left text-3xl text-white sm:pb-4 sm:pt-8 md:text-5xl">
-                  Popular
-                </h2>
-                <Carousel movieCards={popularMovieCards} />
-              </>
-            )}
-            {!!openingMovieCards.length && (
-              <>
-                <h2 className="pl-8 text-left text-3xl text-white sm:pb-4 md:text-5xl">
-                  Opening this week
-                </h2>
-                <Carousel movieCards={openingMovieCards} />
-              </>
-            )}
-            {!!upcomingMovieCards.length && (
-              <>
-                <h2 className="pl-8 text-left text-3xl text-white sm:pb-4 md:text-5xl">
-                  Upcoming
-                </h2>
-                <Carousel movieCards={upcomingMovieCards} />
-              </>
-            )}
+            <MovieRow title="Popular" movies={moviesPopular} />
+            <MovieRow title="Opening this week" movies={moviesOpening} />
+            <MovieRow title="Upcoming" movies={upComingMovies} />
+            <News newsStories={newsStories} />
           </>
         )}
       </main>

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,78 +1,144 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck 
+import Link from 'next/link'
+import { useState } from 'react'
+import type { WatchListItem } from '@prisma/client'
 import Layout from '@layout/default'
 import { api } from '@/utils/api'
 import { useSession } from 'next-auth/react'
-import { useState } from 'react'
 import MovieGrid from '@/components/MovieGrid/MovieGrid'
 import MovieCard from '@/components/MovieCard/MovieCard'
+import MovieCardSkeleton from '@/components/MovieCard/MovieCardSkeleton'
 import ProfileCard from '@/components/ProfileCard/ProfileCard'
 import { useAutoAnimate } from '@formkit/auto-animate/react'
 
+type Tab = 'watchlist' | 'seen'
+type SortKey = 'title' | 'rating' | 'tomato'
+
+const sorters: Record<SortKey, (a: WatchListItem, b: WatchListItem) => number> = {
+  title: (a, b) => a.name.localeCompare(b.name),
+  rating: (a, b) => (b.userRating ?? 0) - (a.userRating ?? 0),
+  tomato: (a, b) => (b.tomatoMeter ?? 0) - (a.tomatoMeter ?? 0),
+}
+
 const Profile = () => {
-  const [animationParent] = useAutoAnimate()
+  const [animationParent] = useAutoAnimate<HTMLDivElement>()
+  const [selected, setSelected] = useState<Tab>('watchlist')
+  const [sort, setSort] = useState<SortKey>('title')
+  const { data: sessionData, status } = useSession()
 
-  const [selected, setSelected] = useState('watchlist')
-  const { data: sessionData } = useSession()
-  const profileData = api.user.query.useQuery()
-  const ratedMovies = profileData.data?.movies.filter(
-    (movie) => movie.userRating
-  )
-  const watchList = profileData.data?.movies.filter(
-    (movie) => !movie.userRating
-  )
+  const profileData = api.user.query.useQuery(undefined, {
+    enabled: !!sessionData,
+  })
 
-  const ratedMovieCards =
-    ratedMovies?.map((movie, idx) => {
-      return <MovieCard key={idx} {...movie} />
-    }) || null
-
-  const watchListMovieCards =
-    watchList?.map((movie, idx) => {
-      return <MovieCard key={idx} {...movie} />
-    }) || null
-
-  if (!sessionData) {
+  if (status === 'loading') {
     return (
       <Layout>
-        <h1 className="text-center text-3xl text-white xl:text-5xl">
-          Please sign in to view your profile
-        </h1>
+        <p className="py-20 text-center text-xl text-zinc-400">Loading…</p>
       </Layout>
     )
   }
 
+  if (!sessionData) {
+    return (
+      <Layout>
+        <div className="px-4 py-24 text-center">
+          <h1 className="mb-4 text-3xl font-bold text-white xl:text-4xl">
+            Please sign in to view your profile
+          </h1>
+          <Link href="/" className="text-pink-400 underline">
+            Back to home
+          </Link>
+        </div>
+      </Layout>
+    )
+  }
+
+  const movies = profileData.data?.movies ?? []
+  const rated = movies.filter((movie) => movie.userRating)
+  const watchList = movies.filter((movie) => !movie.userRating)
+  const active = selected === 'seen' ? rated : watchList
+  const sorted = [...active].sort(sorters[sort])
+  const isLoading = profileData.isLoading
+
+  const tabs: { key: Tab; label: string; count: number }[] = [
+    { key: 'watchlist', label: 'Watchlist', count: watchList.length },
+    { key: 'seen', label: 'Seen', count: rated.length },
+  ]
+
   return (
     <Layout>
-      <div className="w-11/12 mx-auto" ref={animationParent}>
-        {/* <h1 className="text-center text-3xl text-white xl:text-5xl mb-8">
-          {profileData.data?.user?.name} Profile
-        </h1> */}
-        <ProfileCard user={profileData.data?.user} rated={ratedMovies} watchList={watchList}  />
-        <div className="mb-20 flex items-center justify-center text-white">
-          <button
-            className={`text-md bordered py-2 px-4 font-heading text-white sm:text-xl ${
-              selected === 'watchlist' && 'rounded bg-gray-800'
-            }`}
-            onClick={() => setSelected('watchlist')}
-          >
-            WatchList
-          </button>
-          <button
-            className={`text-md bordered py-2 px-4 font-heading text-white sm:text-xl ${
-              selected === 'seen' && 'rounded bg-gray-800'
-            }`}
-            onClick={() => setSelected('seen')}
-          >
-            Seen
-          </button>
+      <div className="mx-auto w-11/12 max-w-screen-xl pb-16">
+        <ProfileCard
+          user={profileData.data?.user}
+          rated={rated}
+          watchList={watchList}
+        />
+
+        <div className="mb-8 flex flex-col items-center justify-between gap-4 sm:flex-row">
+          {/* Segmented tabs */}
+          <div className="inline-flex rounded-full border border-zinc-800 bg-zinc-900/70 p-1">
+            {tabs.map((tab) => (
+              <button
+                key={tab.key}
+                onClick={() => setSelected(tab.key)}
+                className={`rounded-full px-5 py-2 font-heading text-sm font-semibold transition sm:text-base ${
+                  selected === tab.key
+                    ? 'bg-gradient-to-br from-pink-500 to-red-600 text-white'
+                    : 'text-zinc-400 hover:text-white'
+                }`}
+              >
+                {tab.label}{' '}
+                <span
+                  className={
+                    selected === tab.key ? 'text-white/80' : 'text-zinc-500'
+                  }
+                >
+                  {tab.count}
+                </span>
+              </button>
+            ))}
+          </div>
+
+          {/* Sort */}
+          <label className="flex items-center gap-2 text-sm text-zinc-400">
+            Sort by
+            <select
+              value={sort}
+              onChange={(e) => setSort(e.target.value as SortKey)}
+              className="rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-white outline-none focus:border-pink-500"
+            >
+              <option value="title">Title (A–Z)</option>
+              {selected === 'seen' && <option value="rating">Your rating</option>}
+              <option value="tomato">Tomatometer</option>
+            </select>
+          </label>
         </div>
-        {selected === 'watchlist' && watchListMovieCards?.length && (
-          <MovieGrid movieCards={watchListMovieCards} />
-        )}
-        {selected === 'seen' && ratedMovieCards?.length && (
-          <MovieGrid movieCards={ratedMovieCards} />
-        )}
+
+        <div ref={animationParent}>
+          {isLoading ? (
+            <MovieGrid
+              movieCards={Array.from({ length: 6 }).map((_, idx) => (
+                <MovieCardSkeleton key={idx} />
+              ))}
+            />
+          ) : sorted.length > 0 ? (
+            <MovieGrid
+              movieCards={sorted.map((movie) => (
+                <MovieCard key={movie.id} {...movie} />
+              ))}
+            />
+          ) : (
+            <div className="py-16 text-center">
+              <p className="mb-3 text-xl text-zinc-300">
+                {selected === 'seen'
+                  ? "You haven't rated any movies yet."
+                  : 'Your watchlist is empty.'}
+              </p>
+              <Link href="/" className="btn-brand">
+                Find movies
+              </Link>
+            </div>
+          )}
+        </div>
       </div>
     </Layout>
   )

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -23,7 +23,7 @@ const Signin = () => {
     <div className="flex flex-col items-center bg-gradient-to-b from-[#000000] to-[#1e1e1e] px-4">
       <div className="container flex min-h-screen w-full flex-col items-start justify-between px-7 pb-7 pt-3 text-white xl:w-5/12">
         <Link className="mx-auto" href="/">
-          <h1 className="mt-8 bg-gradient-to-br from-pink-400 to-red-600 bg-clip-text font-heading text-5xl font-extrabold text-transparent sm:text-3xl">
+          <h1 className="gradient-text mt-8 font-heading text-4xl font-extrabold sm:text-5xl">
             Movie Fan
           </h1>
         </Link>

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod';
 import { createTRPCRouter, protectedProcedure } from './../trpc';
 
 export const UserRouter = createTRPCRouter({

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,17 +2,75 @@
 @tailwind components;
 @tailwind utilities;
 
-@layer components {
-  .login-btn {
-    @apply bg-slate-800 py-3 px-5 rounded-lg border-pink-600 border-2 hover:bg-slate-700 transition-all;
+@layer base {
+  body {
+    @apply bg-black text-white;
   }
-
 }
 
-    .grid-cards {
-    grid-template-columns: repeat(auto-fill, minmax(300px, 400px));
+@layer components {
+  .login-btn {
+    @apply flex items-center justify-center gap-2 rounded-lg border-2 border-pink-600 bg-slate-800 py-3 px-5 transition-all hover:bg-slate-700;
   }
 
-  .grid-credit-cards {
-    grid-template-columns: repeat(auto-fit, 196px);
+  /* Primary call to action — the brand gradient in pill form */
+  .btn-brand {
+    @apply inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-br from-pink-500 to-red-600 px-6 py-3 font-heading font-semibold text-white shadow-lg shadow-red-900/30 transition hover:from-pink-400 hover:to-red-500 hover:shadow-red-900/50 active:scale-95 disabled:cursor-not-allowed disabled:opacity-50;
   }
+
+  /* Secondary action — outlined on a dark surface */
+  .btn-ghost {
+    @apply inline-flex items-center justify-center gap-2 rounded-full border border-zinc-700 bg-zinc-900/60 px-6 py-3 font-heading font-semibold text-white transition hover:border-zinc-500 hover:bg-zinc-800 active:scale-95;
+  }
+
+  .chip {
+    @apply inline-flex items-center gap-1 rounded-full border border-zinc-700 bg-zinc-800/80 px-3 py-1 text-sm text-zinc-200;
+  }
+
+  .surface {
+    @apply rounded-2xl border border-zinc-800 bg-zinc-900/70;
+  }
+
+  .section-heading {
+    @apply font-heading text-2xl font-bold text-white sm:text-3xl;
+  }
+
+  .gradient-text {
+    @apply bg-gradient-to-br from-pink-400 to-red-600 bg-clip-text text-transparent;
+  }
+}
+
+@layer utilities {
+  .hide-scrollbar {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .hide-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+  /* Softly fades the left/right edges of a horizontal scroll row */
+  .edge-fade-x {
+    -webkit-mask-image: linear-gradient(
+      to right,
+      transparent,
+      black 2.5%,
+      black 97.5%,
+      transparent
+    );
+    mask-image: linear-gradient(
+      to right,
+      transparent,
+      black 2.5%,
+      black 97.5%,
+      transparent
+    );
+  }
+}
+
+.grid-cards {
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+}
+
+.grid-credit-cards {
+  grid-template-columns: repeat(auto-fit, 196px);
+}

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,15 +1,22 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+type Debounced<T extends (...args: any[]) => any> = ((
+  ...args: Parameters<T>
+) => void) & { cancel: () => void }
+
 const debounce = <T extends (...args: any[]) => ReturnType<T>>(
   callback: T,
   timeout: number
-): ((...args: Parameters<T>) => void) => {
+): Debounced<T> => {
   let timer: ReturnType<typeof setTimeout>
 
-  return (...args: Parameters<T>) => {
+  const debounced = (...args: Parameters<T>) => {
     clearTimeout(timer)
     timer = setTimeout(() => {
       callback(...args)
     }, timeout)
   }
+  debounced.cancel = () => clearTimeout(timer)
+
+  return debounced
 }
 export default debounce

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -6,21 +6,28 @@ module.exports = {
     './app/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
   ],
+  future: {
+    hoverOnlyWhenSupported: true,
+  },
   theme: {
     extend: {
       fontFamily: {
         heading: [`var(--font-overPass)`],
         body: [`var(--font-kronaOne)`],
       },
-      future: {
-        hoverOnlyWhenSupported: true,
+      colors: {
+        brand: {
+          pink: '#f472b6',
+          red: '#dc2626',
+        },
+        surface: {
+          DEFAULT: '#18181b',
+          light: '#27272a',
+          border: '#3f3f46',
+        },
       },
       backgroundImage: {
         divider: "url('/divider.svg')",
-      },
-      color: {
-        transparent: 'transparent',
-        current: 'currentColor',
       },
       animation: {
         border: 'border 4s ease infinite',


### PR DESCRIPTION
A full visual refresh across the app, using data the Flixster API already returned but the UI ignored.

## Design foundation
- Brand color/utility layer in the Tailwind theme (gradient text, surface cards, chips, pill buttons, edge-fade + hidden-scrollbar helpers); fixed the misplaced `future`/`colors` config keys
- Sticky blur nav with consistent avatar/sign-in; per-page OG/meta; toned-down footer

## Homepage
- Backdrop hero from the top popular movie
- Captioned cards (title / year / tomatometer / your-rating badges)
- Polished carousel: edge fade, hover-only arrows, hidden scrollbar, native swipe
- Reworked search: icon, clear button, result count, loading skeletons
- News renders styled cards and hides when empty

## Movie details
- Backdrop hero + floating poster, fact/genre chips, dual critic+audience scores with counts
- Styled consensus blockquote, trailer with the movie's own backdrop poster, photo gallery, cast + crew strips
- "Where to watch" Fandango block, dark skeleton mirroring the layout, sticky mobile action bar

## Profile & sign-in
- Segmented tabs with counts, sort controls, empty states, star ratings on rated cards (removed page-wide `ts-nocheck`)
- Fixed the sign-in logo's inverted responsive sizing

## Test plan
- [x] `tsc --noEmit`, `next lint` (clean), `next build` all pass
- [x] Verified in browser at desktop (1280) and mobile (375): home, movie details, sign-in
- [x] Confirmed no duplicate-key or image warnings after fixes
- [ ] Profile page requires auth — not exercisable in preview; logic/build verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)