### PR TITLE
Fix auth boot crash: drop unused Discord env vars, refresh .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,15 +5,36 @@
 # If you are cloning this repo, create a copy of this file named `.env` and populate it with your secrets.
 
 # When adding additional env variables, the schema in /env/schema.mjs should be updated accordingly
+
 # Prisma
-DATABASE_URL=file:./db.sqlite
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/movie-fan
+# Only needed when running `prisma migrate dev` against a hosted DB.
+SHADOW_DATABASE_URL=
 
 # Next Auth
 # You can generate the secret via 'openssl rand -base64 32' on Linux
-# More info: https://next-auth.js.org/configuration/options#secret
-# NEXTAUTH_SECRET=
+# More info: https://authjs.dev/getting-started/deployment#auth_secret
+NEXTAUTH_SECRET=
 NEXTAUTH_URL=http://localhost:3000
 
-# Next Auth Discord Provider
-DISCORD_CLIENT_ID=
-DISCORD_CLIENT_SECRET=
+# Google provider
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# GitHub provider
+GITHUB_ID=
+GITHUB_SECRET=
+
+# Facebook provider
+FACEBOOK_CLIENT_ID=
+FACEBOOK_CLIENT_SECRET=
+
+# Email (Nodemailer) provider
+EMAIL_SERVER_HOST=
+EMAIL_SERVER_PORT=
+EMAIL_SERVER_USER=
+EMAIL_SERVER_PASSWORD=
+EMAIL_FROM=
+
+# Movie data (RapidAPI)
+RAPID_API_KEY=

--- a/src/env/schema.mjs
+++ b/src/env/schema.mjs
@@ -19,8 +19,6 @@ export const serverSchema = z.object({
     // VERCEL_URL doesn't include `https` so it cant be validated as a URL
     process.env.VERCEL ? z.string() : z.string().url()
   ),
-  DISCORD_CLIENT_ID: z.string(),
-  DISCORD_CLIENT_SECRET: z.string(),
   GOOGLE_CLIENT_ID: z.string(),
   GOOGLE_CLIENT_SECRET: z.string(),
   GITHUB_ID: z.string(),


### PR DESCRIPTION
## Summary

Auth providers migrated to Google, GitHub, Facebook, and email (Nodemailer), and Discord was dropped from `src/server/auth.ts` — but the env config wasn't updated to match. This broke auth two ways:

1. **Boot crash.** `src/env/schema.mjs` still *required* `DISCORD_CLIENT_ID` and `DISCORD_CLIENT_SECRET`. That schema is parsed at import time and throws on any missing var, so the entire app — including every `/api/auth/*` route — failed to start unless dummy Discord values were set for a provider that no longer exists.
2. **Broken setup path.** `.env.example` only documented Discord + `NEXTAUTH_URL`, so a `.env` built from it was missing every variable the real providers need, causing env validation to fail immediately.

## Changes

- **`src/env/schema.mjs`** — removed the unused `DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET` requirements.
- **`.env.example`** — rewrote to document the providers actually in use (`GOOGLE_*`, `GITHUB_*`, `FACEBOOK_*`, `EMAIL_*`) plus `NEXTAUTH_SECRET` and `RAPID_API_KEY`, and pointed `DATABASE_URL` at Postgres (the datasource in `schema.prisma`).

No provider wiring, session handling, or route code needed changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmTyMTSwagZdpM8Z5bkTf3)_