### PR TITLE
Redesign homepage layout with hero and news side-by-side

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -72,10 +72,16 @@ export default function HomeClient({ data }: { data: HomeData }) {
   const showSkeletons = isSearching && searchQuery.isLoading
   const noResults = isSearching && searchQuery.isSuccess && results.length === 0
   const featured = popular[0]
+  const hasNews = (news?.length ?? 0) > 0
 
   return (
     <main className="pb-10">
-      {!isSearching && featured && <Hero movie={featured} />}
+      {!isSearching && (featured || hasNews) && (
+        <div className="mx-auto grid max-w-screen-2xl grid-cols-1 items-start gap-6 px-4 py-6 sm:px-8 lg:grid-cols-2">
+          {featured && <Hero movie={featured} />}
+          {hasNews && <News newsStories={news} />}
+        </div>
+      )}
 
       <div className="px-4 py-6 sm:px-8">
         <Search
@@ -136,7 +142,6 @@ export default function HomeClient({ data }: { data: HomeData }) {
           <MovieRow title="Popular" movies={popular} />
           <MovieRow title="Opening this week" movies={opening} />
           <MovieRow title="Upcoming" movies={upcoming} />
-          <News newsStories={news} />
         </>
       )}
     </main>

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -15,7 +15,7 @@ const Hero: FC<HeroProps> = ({ movie }) => {
   const score = movie.tomatoMeter ?? movie.tomatoRating?.tomatometer ?? null
 
   return (
-    <section className="relative overflow-hidden">
+    <section className="relative h-full overflow-hidden rounded-2xl">
       {/* Blurred, darkened poster as an ambient backdrop */}
       <div className="absolute inset-0">
         <Image

--- a/src/components/News/News.tsx
+++ b/src/components/News/News.tsx
@@ -20,11 +20,11 @@ const News: FC<NewsStoryProps> = ({ newsStories }) => {
   if (stories.length === 0) return null
 
   return (
-    <section className="mx-auto w-full max-w-screen-xl px-4 py-6 text-white sm:px-8">
+    <section className="flex w-full flex-col text-white">
       <h2 className="section-heading mb-4">
         <span className="gradient-text">News</span>
       </h2>
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+      <div className="flex flex-1 flex-col gap-6">
         {mainStory?.mainImage?.url && (
           <a
             href={mainStory.link}
@@ -47,7 +47,7 @@ const News: FC<NewsStoryProps> = ({ newsStories }) => {
             </Balancer>
           </a>
         )}
-        <ul className="surface flex flex-col divide-y divide-zinc-800">
+        <ul className="surface flex flex-1 flex-col divide-y divide-zinc-800">
           {restStories.map((story: NewStory) => (
             <li key={story.id}>
               <a


### PR DESCRIPTION
## Summary
Restructured the homepage layout to display the Hero section and News component side-by-side in a grid layout, rather than stacking them vertically. This improves the visual hierarchy and makes better use of horizontal screen space.

## Key Changes
- **Layout restructuring**: Moved the News component from the bottom of the page into a new grid container alongside the Hero section at the top
- **Conditional rendering**: Updated the hero section to display when either a featured movie OR news stories are available (previously required a featured movie)
- **Grid layout**: Implemented a responsive 2-column grid layout on larger screens (lg breakpoint) that collapses to single column on mobile
- **Component styling updates**:
  - Hero: Added `h-full` and `rounded-2xl` to fill grid cell and add rounded corners
  - News: Removed fixed width/padding constraints to flex within grid cell, adjusted internal grid to flex column layout
  - News list: Added `flex-1` to allow proper vertical expansion within the flex container

## Implementation Details
- The new grid uses `max-w-screen-2xl` for consistent max-width with other page sections
- Both Hero and News components now flex to fill available space within their grid cells
- The layout gracefully handles cases where only one component is available (featured movie OR news stories)
- Maintains responsive behavior with proper spacing and padding adjustments

https://claude.ai/code/session_01NXbYVwZ7t7DMGk19SYM6A8