### PR TITLE
Interactive UX: quick-add, rotating hero, profile stats, and more

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { keepPreviousData } from '@tanstack/react-query'
 import type { HomeData } from '@/types/main'
 import type { MovieCardProps } from '@/components/MovieCard/types'
@@ -9,7 +9,7 @@ import MovieCard from '@/components/MovieCard/MovieCard'
 import MovieCardSkeleton from '@/components/MovieCard/MovieCardSkeleton'
 import Carousel from '@/components/Carousel/Carousel'
 import Hero from '@/components/Hero/Hero'
-import Search from '@/components/Search/Search'
+import Search, { saveRecentSearch } from '@/components/Search/Search'
 import News from '@/components/News/News'
 import SearchResults from '@/components/SearchResults/SearchResults'
 
@@ -19,9 +19,11 @@ import debounce from '@/utils/debounce'
 const MovieRow = ({
   title,
   movies,
+  ranked = false,
 }: {
   title: string
   movies: MovieCardProps[]
+  ranked?: boolean
 }) => {
   if (!movies?.length) return null
   return (
@@ -30,8 +32,12 @@ const MovieRow = ({
         <span className="gradient-text">{title}</span>
       </h2>
       <Carousel
-        movieCards={movies.map((movie) => (
-          <MovieCard key={movie.emsVersionId} {...movie} />
+        movieCards={movies.map((movie, idx) => (
+          <MovieCard
+            key={movie.emsVersionId}
+            {...movie}
+            rank={ranked && idx < 10 ? idx + 1 : undefined}
+          />
         ))}
       />
     </section>
@@ -39,6 +45,9 @@ const MovieRow = ({
 }
 
 export default function HomeClient({ data }: { data: HomeData }) {
+  // inputValue is what's in the box; query is the debounced value that
+  // actually drives the API request
+  const [inputValue, setInputValue] = useState('')
   const [query, setQuery] = useState('')
   const { popular, opening, upcoming, news } = data
 
@@ -58,6 +67,7 @@ export default function HomeClient({ data }: { data: HomeData }) {
   ).current
 
   const handleQueryChange = (value: string) => {
+    setInputValue(value)
     const trimmed = value.trim()
     if (trimmed === '') {
       debouncedSetQuery.cancel()
@@ -67,24 +77,43 @@ export default function HomeClient({ data }: { data: HomeData }) {
     }
   }
 
+  // Deep link: /?q=Tom+Hanks searches immediately (cast cards link here)
+  useEffect(() => {
+    const q = new URLSearchParams(window.location.search).get('q')
+    if (q?.trim()) {
+      setInputValue(q)
+      setQuery(q.trim())
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   const isSearching = query.length > 0
   const results: MovieCardProps[] = searchQuery.data?.movies || []
   const showSkeletons = isSearching && searchQuery.isLoading
   const noResults = isSearching && searchQuery.isSuccess && results.length === 0
-  const featured = popular[0]
+
+  // Remember searches that actually found something
+  useEffect(() => {
+    if (isSearching && searchQuery.isSuccess && results.length > 0) {
+      saveRecentSearch(query)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query, isSearching, searchQuery.isSuccess, results.length])
+
   const hasNews = (news?.length ?? 0) > 0
 
   return (
     <main className="pb-10">
-      {!isSearching && (featured || hasNews) && (
+      {!isSearching && (popular.length > 0 || hasNews) && (
         <div className="mx-auto grid max-w-screen-2xl grid-cols-1 items-start gap-6 px-4 py-6 sm:px-8 lg:grid-cols-2">
-          {featured && <Hero movie={featured} />}
+          {popular.length > 0 && <Hero movies={popular.slice(0, 5)} />}
           {hasNews && <News newsStories={news} />}
         </div>
       )}
 
       <div className="px-4 py-6 sm:px-8">
         <Search
+          value={inputValue}
           loading={searchQuery.isFetching}
           onQueryChange={handleQueryChange}
         />
@@ -139,7 +168,8 @@ export default function HomeClient({ data }: { data: HomeData }) {
         </section>
       ) : (
         <>
-          <MovieRow title="Popular" movies={popular} />
+          <MovieRow title="Top 10 today" movies={popular.slice(0, 10)} ranked />
+          <MovieRow title="Popular" movies={popular.slice(10)} />
           <MovieRow title="Opening this week" movies={opening} />
           <MovieRow title="Upcoming" movies={upcoming} />
         </>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -9,6 +9,7 @@ import MovieGrid from '@/components/MovieGrid/MovieGrid'
 import MovieCard from '@/components/MovieCard/MovieCard'
 import MovieCardSkeleton from '@/components/MovieCard/MovieCardSkeleton'
 import ProfileCard from '@/components/ProfileCard/ProfileCard'
+import ProfileStats from '@/components/ProfileStats/ProfileStats'
 import { useAutoAnimate } from '@formkit/auto-animate/react'
 
 type Tab = 'watchlist' | 'seen'
@@ -24,6 +25,7 @@ export default function ProfilePage() {
   const [animationParent] = useAutoAnimate<HTMLDivElement>()
   const [selected, setSelected] = useState<Tab>('watchlist')
   const [sort, setSort] = useState<SortKey>('title')
+  const [genreFilter, setGenreFilter] = useState<string | null>(null)
   const { data: sessionData, status } = useSession()
 
   const profileData = api.user.query.useQuery(undefined, {
@@ -51,7 +53,17 @@ export default function ProfilePage() {
   const rated = movies.filter((movie) => movie.userRating)
   const watchList = movies.filter((movie) => !movie.userRating)
   const active = selected === 'seen' ? rated : watchList
-  const sorted = [...active].sort(sorters[sort])
+
+  // Genre chips reflect what's actually in the active tab
+  const genres = [
+    ...new Set(active.flatMap((movie) => movie.genres || [])),
+  ].sort()
+  const effectiveFilter =
+    genreFilter && genres.includes(genreFilter) ? genreFilter : null
+  const filtered = effectiveFilter
+    ? active.filter((movie) => (movie.genres || []).includes(effectiveFilter))
+    : active
+  const sorted = [...filtered].sort(sorters[sort])
   const isLoading = profileData.isLoading
 
   const tabs: { key: Tab; label: string; count: number }[] = [
@@ -67,7 +79,9 @@ export default function ProfilePage() {
         watchList={watchList}
       />
 
-      <div className="mb-8 flex flex-col items-center justify-between gap-4 sm:flex-row">
+      <ProfileStats movies={movies} />
+
+      <div className="mb-4 flex flex-col items-center justify-between gap-4 sm:flex-row">
         {/* Segmented tabs */}
         <div className="inline-flex rounded-full border border-zinc-800 bg-zinc-900/70 p-1">
           {tabs.map((tab) => (
@@ -107,6 +121,37 @@ export default function ProfilePage() {
         </label>
       </div>
 
+      {/* Genre filter chips */}
+      {genres.length > 1 && (
+        <div className="mb-8 flex flex-wrap justify-center gap-2 sm:justify-start">
+          <button
+            onClick={() => setGenreFilter(null)}
+            className={`rounded-full px-4 py-1.5 text-sm font-semibold transition ${
+              effectiveFilter === null
+                ? 'bg-gradient-to-br from-pink-500 to-red-600 text-white'
+                : 'border border-zinc-700 bg-zinc-900/70 text-zinc-400 hover:border-zinc-500 hover:text-white'
+            }`}
+          >
+            All
+          </button>
+          {genres.map((genre) => (
+            <button
+              key={genre}
+              onClick={() =>
+                setGenreFilter(effectiveFilter === genre ? null : genre)
+              }
+              className={`rounded-full px-4 py-1.5 text-sm font-semibold transition ${
+                effectiveFilter === genre
+                  ? 'bg-gradient-to-br from-pink-500 to-red-600 text-white'
+                  : 'border border-zinc-700 bg-zinc-900/70 text-zinc-400 hover:border-zinc-500 hover:text-white'
+              }`}
+            >
+              {genre}
+            </button>
+          ))}
+        </div>
+      )}
+
       <div ref={animationParent}>
         {isLoading ? (
           <MovieGrid
@@ -120,6 +165,15 @@ export default function ProfilePage() {
               <MovieCard key={movie.id} {...movie} />
             ))}
           />
+        ) : effectiveFilter ? (
+          <div className="py-16 text-center">
+            <p className="mb-3 text-xl text-zinc-300">
+              No {effectiveFilter} movies here yet.
+            </p>
+            <button className="btn-ghost" onClick={() => setGenreFilter(null)}>
+              Show all genres
+            </button>
+          </div>
         ) : (
           <div className="py-16 text-center">
             <p className="mb-3 text-xl text-zinc-300">

--- a/src/components/CastCard/CastCard.tsx
+++ b/src/components/CastCard/CastCard.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react'
 import type { CastCardProps } from './types'
 import Image from 'next/image'
+import Link from 'next/link'
 
 const CastCard: FC<CastCardProps> = ({
   role,
@@ -10,25 +11,40 @@ const CastCard: FC<CastCardProps> = ({
 }) => {
   const subtitle = characterName || role
 
-  return (
-    <div className="w-28 shrink-0 text-center sm:w-full">
-      <div className="relative aspect-[2/3] overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900">
+  const card = (
+    <>
+      <div className="relative aspect-[2/3] overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900 transition duration-300 group-hover:border-zinc-600">
         <Image
           src={headShotImage?.url || '/Default-Avatar.png'}
           fill
           sizes="(max-width: 640px) 30vw, 160px"
-          className="object-cover"
+          className="object-cover transition duration-300 group-hover:scale-105"
           alt={`${name} headshot`}
         />
       </div>
       {name && (
-        <p className="mt-2 truncate text-sm font-semibold text-white">{name}</p>
+        <p className="mt-2 truncate text-sm font-semibold text-white transition group-hover:text-pink-400">
+          {name}
+        </p>
       )}
-      {subtitle && (
-        <p className="truncate text-xs text-zinc-400">{subtitle}</p>
-      )}
-    </div>
+      {subtitle && <p className="truncate text-xs text-zinc-400">{subtitle}</p>}
+    </>
   )
+
+  // Clicking a person searches their name — an easy way to find their other movies
+  if (name) {
+    return (
+      <Link
+        href={`/?q=${encodeURIComponent(name)}`}
+        title={`Search for ${name}`}
+        className="group w-28 shrink-0 text-center sm:w-full"
+      >
+        {card}
+      </Link>
+    )
+  }
+
+  return <div className="group w-28 shrink-0 text-center sm:w-full">{card}</div>
 }
 
 export default CastCard

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -1,63 +1,178 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
 import type { FC } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
+import { HiChevronLeft, HiChevronRight, HiHeart, HiOutlineHeart } from 'react-icons/hi'
+import { CgSpinner } from 'react-icons/cg'
 import type { MovieCardProps } from '@/components/MovieCard/types'
+import { useWatchlist } from '@/hooks/useWatchlist'
+
+const ROTATE_MS = 6000
 
 interface HeroProps {
-  movie: MovieCardProps
+  movies: MovieCardProps[]
 }
 
-const Hero: FC<HeroProps> = ({ movie }) => {
-  const poster =
-    (typeof movie.posterImage === 'string'
-      ? movie.posterImage
-      : movie.posterImage?.url) || '/placeholderposter.png'
-  const score = movie.tomatoMeter ?? movie.tomatoRating?.tomatometer ?? null
+const Hero: FC<HeroProps> = ({ movies }) => {
+  const slides = movies.slice(0, 5)
+  const [index, setIndex] = useState(0)
+  const [paused, setPaused] = useState(false)
+  const { has, toggle, pendingId } = useWatchlist()
+  // Bumped on manual navigation so the auto-advance interval restarts and
+  // doesn't fire right after a click
+  const [restartKey, setRestartKey] = useState(0)
+
+  const goTo = useCallback(
+    (next: number) => {
+      setRestartKey((key) => key + 1)
+      setIndex((next + slides.length) % slides.length)
+    },
+    [slides.length]
+  )
+
+  useEffect(() => {
+    if (slides.length < 2 || paused) return
+    // Respect users who prefer reduced motion: no auto-rotation
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+    const timer = setInterval(
+      () => setIndex((current) => (current + 1) % slides.length),
+      ROTATE_MS
+    )
+    return () => clearInterval(timer)
+  }, [slides.length, paused, restartKey])
+
+  if (slides.length === 0) return null
 
   return (
-    <section className="relative h-full overflow-hidden rounded-2xl">
-      {/* Blurred, darkened poster as an ambient backdrop */}
-      <div className="absolute inset-0">
-        <Image
-          src={poster}
-          fill
-          priority
-          sizes="100vw"
-          alt=""
-          aria-hidden
-          className="scale-110 object-cover blur-2xl brightness-[0.35]"
-        />
-        <div className="absolute inset-0 bg-gradient-to-t from-black via-black/70 to-transparent" />
-      </div>
+    <section
+      className="group/hero relative h-full overflow-hidden rounded-2xl"
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+      aria-roledescription="carousel"
+      aria-label="Popular movies spotlight"
+    >
+      {slides.map((movie, i) => {
+        const poster =
+          (typeof movie.posterImage === 'string'
+            ? movie.posterImage
+            : movie.posterImage?.url) || '/placeholderposter.png'
+        const score =
+          movie.tomatoMeter ?? movie.tomatoRating?.tomatometer ?? null
+        const active = i === index
+        const onList = has(movie.emsVersionId)
+        const isPending = pendingId === movie.emsVersionId
 
-      <div className="relative mx-auto flex max-w-screen-xl flex-col items-center gap-6 px-4 py-10 sm:flex-row sm:items-end sm:px-8 sm:py-16">
-        <div className="relative aspect-[2/3] w-36 shrink-0 overflow-hidden rounded-xl border border-zinc-700 shadow-2xl sm:w-52">
-          <Image
-            src={poster}
-            fill
-            priority
-            sizes="(max-width: 640px) 40vw, 210px"
-            alt={`${movie.name} poster`}
-            className="object-cover"
-          />
-        </div>
-        <div className="text-center sm:text-left">
-          <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-pink-400">
-            #1 Popular
-          </p>
-          <h2 className="font-heading text-3xl font-bold text-white sm:text-5xl">
-            {movie.name}
-          </h2>
-          {score != null && (
-            <p className="chip mt-4 text-base">🍅 {score}%</p>
-          )}
-          <div className="mt-6">
-            <Link href={`/movie/${movie.emsVersionId}`} className="btn-brand">
-              View details
-            </Link>
+        return (
+          <div
+            key={movie.emsVersionId}
+            className={`transition-opacity duration-700 ${
+              active
+                ? 'relative opacity-100'
+                : 'pointer-events-none absolute inset-0 opacity-0'
+            }`}
+            aria-hidden={!active}
+          >
+            {/* Blurred, darkened poster as an ambient backdrop */}
+            <div className="absolute inset-0">
+              <Image
+                src={poster}
+                fill
+                priority={i === 0}
+                sizes="100vw"
+                alt=""
+                aria-hidden
+                className="scale-110 object-cover blur-2xl brightness-[0.35]"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black via-black/70 to-transparent" />
+            </div>
+
+            <div className="relative mx-auto flex max-w-screen-xl flex-col items-center gap-6 px-4 py-10 pb-14 sm:flex-row sm:items-end sm:px-8 sm:py-16 sm:pb-16">
+              <div className="relative aspect-[2/3] w-36 shrink-0 overflow-hidden rounded-xl border border-zinc-700 shadow-2xl sm:w-52">
+                <Image
+                  src={poster}
+                  fill
+                  priority={i === 0}
+                  sizes="(max-width: 640px) 40vw, 210px"
+                  alt={`${movie.name} poster`}
+                  className="object-cover"
+                />
+              </div>
+              <div className="text-center sm:text-left">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-pink-400">
+                  #{i + 1} Popular
+                </p>
+                <h2 className="font-heading text-3xl font-bold text-white sm:text-5xl">
+                  {movie.name}
+                </h2>
+                {score != null && (
+                  <p className="chip mt-4 text-base">🍅 {score}%</p>
+                )}
+                <div className="mt-6 flex flex-wrap items-center justify-center gap-3 sm:justify-start">
+                  <Link
+                    href={`/movie/${movie.emsVersionId}`}
+                    className="btn-brand"
+                  >
+                    View details
+                  </Link>
+                  <button
+                    className="btn-ghost"
+                    onClick={() => toggle(movie.emsVersionId)}
+                    disabled={isPending}
+                  >
+                    {isPending ? (
+                      <CgSpinner className="h-5 w-5 animate-spin" />
+                    ) : onList ? (
+                      <HiHeart className="h-5 w-5 text-pink-500" />
+                    ) : (
+                      <HiOutlineHeart className="h-5 w-5" />
+                    )}
+                    {onList ? 'On watchlist' : 'Watchlist'}
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
+        )
+      })}
+
+      {slides.length > 1 && (
+        <>
+          {/* Prev / next — revealed on hover like the carousel rows */}
+          <button
+            onClick={() => goTo(index - 1)}
+            aria-label="Previous movie"
+            className="absolute left-3 top-1/2 z-20 hidden -translate-y-1/2 rounded-full bg-black/60 p-2 text-white shadow-lg backdrop-blur transition hover:bg-black/90 sm:group-hover/hero:flex"
+          >
+            <HiChevronLeft className="h-6 w-6" />
+          </button>
+          <button
+            onClick={() => goTo(index + 1)}
+            aria-label="Next movie"
+            className="absolute right-3 top-1/2 z-20 hidden -translate-y-1/2 rounded-full bg-black/60 p-2 text-white shadow-lg backdrop-blur transition hover:bg-black/90 sm:group-hover/hero:flex"
+          >
+            <HiChevronRight className="h-6 w-6" />
+          </button>
+
+          {/* Dots */}
+          <div className="absolute bottom-4 left-1/2 z-20 flex -translate-x-1/2 gap-2">
+            {slides.map((movie, i) => (
+              <button
+                key={movie.emsVersionId}
+                onClick={() => goTo(i)}
+                aria-label={`Go to slide ${i + 1}: ${movie.name}`}
+                aria-current={i === index}
+                className={`h-2.5 rounded-full transition-all ${
+                  i === index
+                    ? 'w-6 bg-pink-500'
+                    : 'w-2.5 bg-zinc-600 hover:bg-zinc-400'
+                }`}
+              />
+            ))}
+          </div>
+        </>
+      )}
     </section>
   )
 }

--- a/src/components/Lightbox/Lightbox.tsx
+++ b/src/components/Lightbox/Lightbox.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+/**
+ * Minimal dependency-free image lightbox: backdrop click / Esc to close,
+ * arrow keys or on-screen chevrons to navigate, with a position counter.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import type { FC } from 'react'
+import Image from 'next/image'
+import { HiChevronLeft, HiChevronRight, HiX } from 'react-icons/hi'
+
+interface LightboxProps {
+  images: { url: string }[]
+  startIndex: number
+  altBase: string
+  onClose: () => void
+}
+
+const Lightbox: FC<LightboxProps> = ({
+  images,
+  startIndex,
+  altBase,
+  onClose,
+}) => {
+  const [index, setIndex] = useState(startIndex)
+
+  const step = useCallback(
+    (direction: number) =>
+      setIndex((current) => (current + direction + images.length) % images.length),
+    [images.length]
+  )
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+      if (e.key === 'ArrowLeft') step(-1)
+      if (e.key === 'ArrowRight') step(1)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    // Lock page scroll while the lightbox is open
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      document.body.style.overflow = previousOverflow
+    }
+  }, [onClose, step])
+
+  const image = images[index]
+  if (!image) return null
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${altBase} photo viewer`}
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/90 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <button
+        onClick={onClose}
+        aria-label="Close photo viewer"
+        className="absolute right-4 top-4 z-10 rounded-full bg-black/60 p-2 text-white transition hover:bg-black/90"
+      >
+        <HiX className="h-6 w-6" />
+      </button>
+
+      {images.length > 1 && (
+        <>
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              step(-1)
+            }}
+            aria-label="Previous photo"
+            className="absolute left-3 z-10 rounded-full bg-black/60 p-2 text-white transition hover:bg-black/90 sm:left-6"
+          >
+            <HiChevronLeft className="h-7 w-7" />
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              step(1)
+            }}
+            aria-label="Next photo"
+            className="absolute right-3 z-10 rounded-full bg-black/60 p-2 text-white transition hover:bg-black/90 sm:right-6"
+          >
+            <HiChevronRight className="h-7 w-7" />
+          </button>
+        </>
+      )}
+
+      <figure
+        className="relative h-[80vh] w-[92vw] max-w-6xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Image
+          src={image.url}
+          fill
+          sizes="92vw"
+          alt={`${altBase} still ${index + 1}`}
+          className="object-contain"
+        />
+        <figcaption className="absolute bottom-2 left-1/2 -translate-x-1/2 rounded-full bg-black/70 px-3 py-1 text-sm text-zinc-300 backdrop-blur">
+          {index + 1} / {images.length}
+        </figcaption>
+      </figure>
+    </div>
+  )
+}
+
+export default Lightbox

--- a/src/components/MovieCard/MovieCard.tsx
+++ b/src/components/MovieCard/MovieCard.tsx
@@ -1,7 +1,12 @@
-import type { FC } from 'react'
+'use client'
+
+import type { FC, MouseEvent } from 'react'
 import type { MovieCardProps } from './types'
 import Image from 'next/image'
 import Link from 'next/link'
+import { HiHeart, HiOutlineHeart } from 'react-icons/hi'
+import { CgSpinner } from 'react-icons/cg'
+import { useWatchlist } from '@/hooks/useWatchlist'
 
 const MovieCard: FC<MovieCardProps> = ({
   name,
@@ -11,7 +16,10 @@ const MovieCard: FC<MovieCardProps> = ({
   tomatoRating,
   tomatoMeter,
   userRating,
+  rank,
 }) => {
+  const { has, toggle, pendingId } = useWatchlist()
+
   // posterImage is a string for watchlist items and an { url } object (whose
   // url may be missing) for API results
   const posterSrc =
@@ -23,35 +31,86 @@ const MovieCard: FC<MovieCardProps> = ({
   const score = tomatoMeter ?? tomatoRating?.tomatometer ?? null
   const stars = typeof userRating === 'number' ? userRating : null
 
+  const onList = has(emsVersionId)
+  const isPending = pendingId === emsVersionId
+
+  const handleHeart = (e: MouseEvent) => {
+    // The heart lives inside the card link — keep the click from navigating
+    e.preventDefault()
+    e.stopPropagation()
+    toggle(emsVersionId)
+  }
+
   return (
     <Link
       href={`/movie/${emsVersionId}`}
-      className="group block w-36 shrink-0 snap-start sm:w-44"
+      className={`group block shrink-0 snap-start ${
+        rank ? 'flex w-48 items-end sm:w-56' : 'w-36 sm:w-44'
+      }`}
     >
-      <div className="relative aspect-[2/3] overflow-hidden rounded-xl border border-zinc-800 bg-zinc-900 shadow-lg transition duration-300 group-hover:border-zinc-600 group-hover:shadow-pink-900/20">
-        <Image
-          className="object-cover transition duration-300 group-hover:scale-105"
-          src={posterSrc}
-          fill
-          sizes="(max-width: 640px) 40vw, 180px"
-          alt={`${name} poster`}
-        />
-        {score != null && (
-          <span className="absolute left-2 top-2 flex items-center gap-1 rounded-full bg-black/75 px-2 py-0.5 text-xs font-semibold text-white backdrop-blur">
-            🍅 {score}%
+      {/* Netflix-style giant rank numeral behind the poster */}
+      {rank && (
+        <span
+          aria-label={`Ranked number ${rank}`}
+          className="-mr-4 select-none font-heading text-[6.5rem] font-black leading-[0.8] text-zinc-800 transition group-hover:text-zinc-700 sm:text-[8rem]"
+          style={{ WebkitTextStroke: '2px rgb(236 72 153 / 0.35)' }}
+        >
+          {rank}
+        </span>
+      )}
+
+      <div className={rank ? 'relative z-10 w-36 sm:w-44' : undefined}>
+        <div className="relative aspect-[2/3] overflow-hidden rounded-xl border border-zinc-800 bg-zinc-900 shadow-lg transition duration-300 group-hover:border-zinc-600 group-hover:shadow-pink-900/20">
+          <Image
+            className="object-cover transition duration-300 group-hover:scale-105"
+            src={posterSrc}
+            fill
+            sizes="(max-width: 640px) 40vw, 180px"
+            alt={`${name} poster`}
+          />
+          {score != null && (
+            <span className="absolute left-2 top-2 flex items-center gap-1 rounded-full bg-black/75 px-2 py-0.5 text-xs font-semibold text-white backdrop-blur">
+              🍅 {score}%
+            </span>
+          )}
+          {stars != null && (
+            <span className="absolute right-2 top-2 flex items-center gap-1 rounded-full bg-black/75 px-2 py-0.5 text-xs font-semibold text-yellow-400 backdrop-blur">
+              ★ {stars}
+            </span>
+          )}
+
+          {/* Hover reveal: darkened base + details hint */}
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-1/2 bg-gradient-to-t from-black/80 to-transparent opacity-0 transition duration-300 group-hover:opacity-100" />
+          <span className="pointer-events-none absolute bottom-2 left-2 rounded-full bg-black/60 px-2.5 py-1 text-xs font-semibold text-white opacity-0 backdrop-blur transition duration-300 group-hover:opacity-100">
+            View details →
           </span>
-        )}
-        {stars != null && (
-          <span className="absolute right-2 top-2 flex items-center gap-1 rounded-full bg-black/75 px-2 py-0.5 text-xs font-semibold text-yellow-400 backdrop-blur">
-            ★ {stars}
-          </span>
-        )}
-      </div>
-      <div className="mt-2 px-0.5">
-        <p className="truncate font-heading text-sm font-semibold text-white transition group-hover:text-pink-400">
-          {name}
-        </p>
-        {year && <p className="text-xs text-zinc-500">{year}</p>}
+
+          {/* Quick add / remove. Always visible on touch, hover-revealed on desktop */}
+          <button
+            onClick={handleHeart}
+            aria-label={onList ? 'Remove from watchlist' : 'Add to watchlist'}
+            title={onList ? 'Remove from watchlist' : 'Add to watchlist'}
+            className={`absolute bottom-2 right-2 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-black/75 backdrop-blur transition duration-300 hover:scale-110 hover:bg-black/90 focus-visible:opacity-100 ${
+              onList
+                ? 'text-pink-500'
+                : 'text-white sm:opacity-0 sm:group-hover:opacity-100'
+            }`}
+          >
+            {isPending ? (
+              <CgSpinner className="h-5 w-5 animate-spin" />
+            ) : onList ? (
+              <HiHeart className="h-5 w-5" />
+            ) : (
+              <HiOutlineHeart className="h-5 w-5" />
+            )}
+          </button>
+        </div>
+        <div className="mt-2 px-0.5">
+          <p className="truncate font-heading text-sm font-semibold text-white transition group-hover:text-pink-400">
+            {name}
+          </p>
+          {year && <p className="text-xs text-zinc-500">{year}</p>}
+        </div>
       </div>
     </Link>
   )

--- a/src/components/MovieCard/types.d.ts
+++ b/src/components/MovieCard/types.d.ts
@@ -11,4 +11,6 @@ export interface MovieCardProps extends ComponentPropsWithRef<'div'> {
   tomatoMeter?: number | null;
   // The signed-in user's own star rating (DB watchlist items only)
   userRating?: number | null;
+  // When set, renders a Netflix-style giant numeral beside the poster
+  rank?: number;
 }

--- a/src/components/MovieDetails/MovieDetails.tsx
+++ b/src/components/MovieDetails/MovieDetails.tsx
@@ -1,21 +1,61 @@
 'use client'
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { useState } from 'react'
 import Image from 'next/image'
 import Balancer from 'react-wrap-balancer'
 import parse, { domToReact } from 'html-react-parser'
 import { useSession, signIn } from 'next-auth/react'
+import { HiOutlineShare, HiCheck } from 'react-icons/hi'
 
 import { api } from '@/utils/api'
 import { createMovieObj } from '@/utils/createMovieObj'
 import type { IMovieDetail } from './types'
 import StarRating from '@/components/StarRating/StarRating'
 import CastGrid from '../CastGrid/CastGrid'
+import Lightbox from '@/components/Lightbox/Lightbox'
 
 const formatRuntime = (minutes?: number | null) => {
   if (!minutes) return null
   const h = Math.floor(minutes / 60)
   const m = minutes % 60
   return h > 0 ? `${h}h ${m}m` : `${m}m`
+}
+
+const formatFullDate = (dateString?: string | null) => {
+  if (!dateString) return null
+  const date = new Date(dateString)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+/** The showtime payload shape varies; pull out anything usable, defensively */
+const theaterName = (theater: any): string | null =>
+  theater?.name || theater?.theaterName || theater?.title || null
+
+const theaterShowtimes = (theater: any): string[] => {
+  const raw = theater?.showtimes || theater?.showTimes || []
+  if (!Array.isArray(raw)) return []
+  return raw
+    .map((showtime: any) => {
+      const value =
+        showtime?.dateTime || showtime?.startTime || showtime?.time || showtime
+      if (typeof value !== 'string') return null
+      const date = new Date(value)
+      if (!Number.isNaN(date.getTime())) {
+        return date.toLocaleTimeString('en-US', {
+          hour: 'numeric',
+          minute: '2-digit',
+        })
+      }
+      // Already a display string like "7:30pm"
+      return /^[\d:apm\s.]+$/i.test(value) ? value : null
+    })
+    .filter((time: string | null): time is string => !!time)
+    .slice(0, 6)
 }
 
 const ScoreBadge = ({
@@ -53,6 +93,8 @@ const ScoreBadge = ({
 const MovieDetails = ({ id, movie }: { id: string; movie: any }) => {
   const { data: session } = useSession()
   const utils = api.useUtils()
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null)
+  const [copied, setCopied] = useState(false)
 
   const invalidateWatchlist = () => {
     utils.movie.query.invalidate({ movieId: id })
@@ -73,12 +115,44 @@ const MovieDetails = ({ id, movie }: { id: string; movie: any }) => {
   const poster = movie.posterImage?.url || '/placeholderposter.png'
   const backdrop = movie.backgroundImage?.url || poster
   const year = movie.releaseDate ? String(movie.releaseDate).slice(0, 4) : null
+  const fullReleaseDate = formatFullDate(movie.releaseDate)
   const runtime = formatRuntime(movie.durationMinutes)
-  const gallery = (movie.images || []).slice(0, 8)
+  const gallery = (movie.images || []).filter((img: any) => img?.url)
   const theaters = movie.showtimeGroupings?.theaters || []
+  const namedTheaters = theaters.filter((theater: any) => theaterName(theater))
   const ticketsUrl = `https://www.fandango.com/search?q=${encodeURIComponent(
     movie.name
   )}`
+
+  const facts: { label: string; value: string | null }[] = [
+    { label: 'Release date', value: fullReleaseDate },
+    { label: 'Runtime', value: runtime },
+    { label: 'Director', value: movie.directedBy || null },
+    { label: 'Box office', value: movie.totalGross || null },
+    {
+      label: 'Rated',
+      value: movie.motionPictureRating?.code
+        ? [movie.motionPictureRating.code, movie.motionPictureRating.description]
+            .filter(Boolean)
+            .join(' — ')
+        : null,
+    },
+  ].filter((fact) => fact.value)
+
+  const handleShare = async () => {
+    const url = window.location.href
+    try {
+      if (navigator.share) {
+        await navigator.share({ title: movie.name, url })
+        return
+      }
+      await navigator.clipboard.writeText(url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      /* user dismissed the share sheet — nothing to do */
+    }
+  }
 
   const handleAddMovie = () => {
     addMovie.mutate({ movieData: createMovieObj(movie as IMovieDetail, id, genres) })
@@ -191,32 +265,53 @@ const MovieDetails = ({ id, movie }: { id: string; movie: any }) => {
               </p>
             )}
 
-            {/* Watchlist / rating actions */}
+            {/* Watchlist / rating / share actions */}
             <div className="mt-8">
-              {!session ? (
-                <button className="btn-brand" onClick={() => signIn()}>
-                  Sign in to add to watchlist &amp; rate
-                </button>
-              ) : (
-                <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
-                  <div className="flex items-center gap-3">
-                    <span className="text-sm text-zinc-400">Your rating:</span>
-                    <StarRating
-                      value={currentUserRating}
-                      onChange={handleSeenMovie}
-                    />
-                  </div>
-                  {onWatchlist ? (
-                    <button className="btn-ghost" onClick={handleRemoveMovie}>
-                      Remove from watchlist
-                    </button>
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+                {!session ? (
+                  <button className="btn-brand" onClick={() => signIn()}>
+                    Sign in to add to watchlist &amp; rate
+                  </button>
+                ) : (
+                  <>
+                    <div className="flex items-center gap-3">
+                      <span className="text-sm text-zinc-400">
+                        Your rating:
+                      </span>
+                      <StarRating
+                        value={currentUserRating}
+                        onChange={handleSeenMovie}
+                      />
+                    </div>
+                    {onWatchlist ? (
+                      <button className="btn-ghost" onClick={handleRemoveMovie}>
+                        Remove from watchlist
+                      </button>
+                    ) : (
+                      <button className="btn-brand" onClick={handleAddMovie}>
+                        + Add to watchlist
+                      </button>
+                    )}
+                  </>
+                )}
+                <button
+                  className="btn-ghost"
+                  onClick={handleShare}
+                  aria-label="Share this movie"
+                >
+                  {copied ? (
+                    <>
+                      <HiCheck className="h-5 w-5 text-green-400" />
+                      Link copied!
+                    </>
                   ) : (
-                    <button className="btn-brand" onClick={handleAddMovie}>
-                      + Add to watchlist
-                    </button>
+                    <>
+                      <HiOutlineShare className="h-5 w-5" />
+                      Share
+                    </>
                   )}
-                </div>
-              )}
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -255,53 +350,121 @@ const MovieDetails = ({ id, movie }: { id: string; movie: any }) => {
           </section>
         )}
 
-        {/* Photo gallery */}
+        {/* Photo gallery — click any still to open the lightbox */}
         {gallery.length > 0 && (
           <section className="my-10">
-            <h3 className="section-heading mb-4">Photos</h3>
+            <h3 className="section-heading mb-4">
+              Photos{' '}
+              <span className="text-base font-normal text-zinc-500">
+                ({gallery.length})
+              </span>
+            </h3>
             <div className="hide-scrollbar edge-fade-x flex gap-4 overflow-x-auto pb-2">
               {gallery.map((img: any, idx: number) => (
-                <div
+                <button
                   key={idx}
-                  className="relative aspect-video h-40 shrink-0 overflow-hidden rounded-lg border border-zinc-800 sm:h-52"
+                  onClick={() => setLightboxIndex(idx)}
+                  aria-label={`View photo ${idx + 1} of ${gallery.length}`}
+                  className="group relative aspect-video h-40 shrink-0 overflow-hidden rounded-lg border border-zinc-800 transition hover:border-zinc-500 sm:h-52"
                 >
                   <Image
                     src={img.url}
                     fill
                     sizes="360px"
                     alt={`${movie.name} still ${idx + 1}`}
-                    className="object-cover"
+                    className="object-cover transition duration-300 group-hover:scale-105"
                   />
-                </div>
+                </button>
               ))}
             </div>
           </section>
+        )}
+
+        {lightboxIndex != null && (
+          <Lightbox
+            images={gallery}
+            startIndex={lightboxIndex}
+            altBase={movie.name}
+            onClose={() => setLightboxIndex(null)}
+          />
         )}
 
         {/* Cast & crew */}
         {movie.cast && <CastGrid cast={movie.cast} title="Cast" />}
         {movie.crew && <CastGrid cast={movie.crew} title="Crew" />}
 
+        {/* Movie facts */}
+        {facts.length > 0 && (
+          <section className="my-10">
+            <h3 className="section-heading mb-4">Details</h3>
+            <dl className="surface grid grid-cols-1 gap-x-8 gap-y-4 p-5 sm:grid-cols-2 lg:grid-cols-3">
+              {facts.map((fact) => (
+                <div key={fact.label}>
+                  <dt className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
+                    {fact.label}
+                  </dt>
+                  <dd className="mt-1 text-zinc-100">{fact.value}</dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+        )}
+
         {/* Where to watch */}
         {theaters.length > 0 && (
           <section className="my-10">
             <h3 className="section-heading mb-4">Where to watch</h3>
-            <div className="surface flex flex-col gap-4 p-5 sm:flex-row sm:items-center sm:justify-between">
-              <p className="text-zinc-300">
-                Playing in{' '}
-                <span className="font-semibold text-white">
-                  {theaters.length}
-                </span>{' '}
-                {theaters.length === 1 ? 'theater' : 'theaters'} near you
-              </p>
-              <a
-                href={ticketsUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="btn-brand"
-              >
-                Get tickets on Fandango
-              </a>
+            <div className="surface flex flex-col gap-4 p-5">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-zinc-300">
+                  Playing in{' '}
+                  <span className="font-semibold text-white">
+                    {theaters.length}
+                  </span>{' '}
+                  {theaters.length === 1 ? 'theater' : 'theaters'} near you
+                </p>
+                <a
+                  href={ticketsUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="btn-brand"
+                >
+                  Get tickets on Fandango
+                </a>
+              </div>
+
+              {/* Theater list when the payload names them */}
+              {namedTheaters.length > 0 && (
+                <ul className="divide-y divide-zinc-800 border-t border-zinc-800">
+                  {namedTheaters.slice(0, 6).map((theater: any, idx: number) => {
+                    const times = theaterShowtimes(theater)
+                    return (
+                      <li
+                        key={idx}
+                        className="flex flex-col gap-2 py-3 sm:flex-row sm:items-center sm:justify-between"
+                      >
+                        <p className="font-semibold text-white">
+                          {theaterName(theater)}
+                        </p>
+                        {times.length > 0 && (
+                          <div className="flex flex-wrap gap-2">
+                            {times.map((time) => (
+                              <span key={time} className="chip text-xs">
+                                {time}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                      </li>
+                    )
+                  })}
+                  {namedTheaters.length > 6 && (
+                    <li className="py-3 text-sm text-zinc-500">
+                      + {namedTheaters.length - 6} more on Fandango
+                    </li>
+                  )}
+                </ul>
+              )}
             </div>
           </section>
         )}

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -1,15 +1,33 @@
 'use client'
 
 import type { FC } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { signIn, signOut, useSession } from 'next-auth/react'
 import Link from 'next/link'
 import Image from 'next/image'
-import { usePathname } from 'next/navigation'
+import { HiOutlineUser, HiOutlineLogout } from 'react-icons/hi'
 
 const Nav: FC = () => {
-  const pathname = usePathname()
-  const onProfilePage = pathname === '/profile'
   const { data: sessionData } = useSession()
+  const [open, setOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // Close the menu on outside click or Escape
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (e: MouseEvent) => {
+      if (!menuRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
 
   return (
     <nav className="sticky top-0 z-50 flex w-full items-center justify-between border-b border-zinc-800/80 bg-black/70 px-4 py-4 backdrop-blur-md sm:px-8">
@@ -20,15 +38,13 @@ const Nav: FC = () => {
       </Link>
       <div className="flex items-center gap-4">
         {sessionData ? (
-          onProfilePage ? (
-            <button className="btn-ghost" onClick={() => signOut({ callbackUrl: '/' })}>
-              Sign Out
-            </button>
-          ) : (
-            <Link
-              href="/profile"
-              className="rounded-full ring-2 ring-transparent transition hover:ring-pink-500"
-              aria-label="Go to your profile"
+          <div className="relative" ref={menuRef}>
+            <button
+              onClick={() => setOpen((current) => !current)}
+              className="block rounded-full ring-2 ring-transparent transition hover:ring-pink-500"
+              aria-label="Open account menu"
+              aria-expanded={open}
+              aria-haspopup="menu"
             >
               <Image
                 src={sessionData.user?.image || '/avatar.png'}
@@ -37,8 +53,43 @@ const Nav: FC = () => {
                 alt="Your profile avatar"
                 className="h-12 w-12 rounded-full object-cover"
               />
-            </Link>
-          )
+            </button>
+
+            {open && (
+              <div
+                role="menu"
+                className="absolute right-0 top-full z-50 mt-2 w-56 overflow-hidden rounded-2xl border border-zinc-800 bg-zinc-900/95 shadow-2xl backdrop-blur"
+              >
+                <div className="border-b border-zinc-800 px-4 py-3">
+                  <p className="truncate font-semibold text-white">
+                    {sessionData.user?.name || 'Movie Fan'}
+                  </p>
+                  {sessionData.user?.email && (
+                    <p className="truncate text-xs text-zinc-500">
+                      {sessionData.user.email}
+                    </p>
+                  )}
+                </div>
+                <Link
+                  href="/profile"
+                  role="menuitem"
+                  onClick={() => setOpen(false)}
+                  className="flex items-center gap-3 px-4 py-3 text-zinc-200 transition hover:bg-zinc-800/80 hover:text-pink-400"
+                >
+                  <HiOutlineUser className="h-5 w-5" />
+                  Profile &amp; watchlist
+                </Link>
+                <button
+                  role="menuitem"
+                  onClick={() => signOut({ callbackUrl: '/' })}
+                  className="flex w-full items-center gap-3 px-4 py-3 text-left text-zinc-200 transition hover:bg-zinc-800/80 hover:text-pink-400"
+                >
+                  <HiOutlineLogout className="h-5 w-5" />
+                  Sign out
+                </button>
+              </div>
+            )}
+          </div>
         ) : (
           <button className="btn-brand" onClick={() => signIn()}>
             Sign in

--- a/src/components/News/News.tsx
+++ b/src/components/News/News.tsx
@@ -1,19 +1,27 @@
+'use client'
+
 import type { NewsStoryProps } from './types'
 import type { FC } from 'react'
 import type { NewStory } from '@/types/main'
 
+import { useState } from 'react'
 import Image from 'next/image'
 import parse from 'html-react-parser'
 import Balancer from 'react-wrap-balancer'
 
+const INITIAL_STORIES = 8
+
 const News: FC<NewsStoryProps> = ({ newsStories }) => {
+  const [expanded, setExpanded] = useState(false)
   const stories = (newsStories || []).filter(
     (story) => !story.title?.toLowerCase().includes('tv')
   )
   const mainStory = stories.find((story) => story.mainImage?.url)
-  const restStories = stories
-    .filter((story) => story.id !== mainStory?.id)
-    .slice(0, 8)
+  const restStories = stories.filter((story) => story.id !== mainStory?.id)
+  const visibleStories = expanded
+    ? restStories
+    : restStories.slice(0, INITIAL_STORIES)
+  const hiddenCount = restStories.length - INITIAL_STORIES
 
   // Nothing to show (the news feed is sometimes empty) — render nothing
   // rather than a stray heading
@@ -47,20 +55,30 @@ const News: FC<NewsStoryProps> = ({ newsStories }) => {
             </Balancer>
           </a>
         )}
-        <ul className="surface flex flex-1 flex-col divide-y divide-zinc-800">
-          {restStories.map((story: NewStory) => (
-            <li key={story.id}>
-              <a
-                className="block px-4 py-3 text-base transition hover:bg-zinc-800/60 hover:text-pink-400 lg:text-lg"
-                href={story.link}
-                target="_blank"
-                rel="noreferrer"
-              >
-                <Balancer>{parse(story.title)}</Balancer>
-              </a>
-            </li>
-          ))}
-        </ul>
+        <div className="surface flex flex-1 flex-col overflow-hidden">
+          <ul className="flex flex-col divide-y divide-zinc-800">
+            {visibleStories.map((story: NewStory) => (
+              <li key={story.id}>
+                <a
+                  className="block px-4 py-3 text-base transition hover:bg-zinc-800/60 hover:text-pink-400 lg:text-lg"
+                  href={story.link}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <Balancer>{parse(story.title)}</Balancer>
+                </a>
+              </li>
+            ))}
+          </ul>
+          {hiddenCount > 0 && (
+            <button
+              onClick={() => setExpanded((current) => !current)}
+              className="border-t border-zinc-800 px-4 py-3 text-sm font-semibold text-pink-400 transition hover:bg-zinc-800/60 hover:text-pink-300"
+            >
+              {expanded ? 'Show less' : `More news (${hiddenCount})`}
+            </button>
+          )}
+        </div>
       </div>
     </section>
   )

--- a/src/components/ProfileStats/ProfileStats.tsx
+++ b/src/components/ProfileStats/ProfileStats.tsx
@@ -1,0 +1,236 @@
+'use client'
+
+/**
+ * "Your taste" dashboard computed entirely from the watchlist rows already
+ * stored in the DB — no extra API calls. Colors were validated for CVD
+ * separation and contrast against the zinc-900 surface:
+ *   you = pink #ec4899, critics = sky #0284c7 (both direct-labeled, so
+ *   identity never rides on color alone).
+ */
+import type { FC } from 'react'
+import type { WatchListItem } from '@prisma/client'
+
+const YOU_COLOR = '#ec4899'
+const CRITICS_COLOR = '#0284c7'
+const MAX_GENRE_BARS = 6
+
+interface ProfileStatsProps {
+  movies: WatchListItem[]
+}
+
+const formatHours = (minutes: number) => {
+  const hours = minutes / 60
+  return hours >= 10 ? Math.round(hours).toString() : hours.toFixed(1)
+}
+
+const ProfileStats: FC<ProfileStatsProps> = ({ movies }) => {
+  if (movies.length === 0) return null
+
+  const rated = movies.filter((movie) => movie.userRating)
+
+  // Favorite genres across everything saved
+  const genreCounts = new Map<string, number>()
+  for (const movie of movies) {
+    for (const genre of movie.genres || []) {
+      genreCounts.set(genre, (genreCounts.get(genre) || 0) + 1)
+    }
+  }
+  const rankedGenres = [...genreCounts.entries()].sort((a, b) => b[1] - a[1])
+  const topGenres = rankedGenres.slice(0, MAX_GENRE_BARS)
+  const otherCount = rankedGenres
+    .slice(MAX_GENRE_BARS)
+    .reduce((sum, [, count]) => sum + count, 0)
+  const maxGenreCount = topGenres[0]?.[1] ?? 0
+
+  // Hours watched: runtimes of everything rated as seen
+  const minutesWatched = rated.reduce(
+    (sum, movie) => sum + (movie.durationMinutes || 0),
+    0
+  )
+
+  // You vs the critics — both on a 0–100 scale (stars are 1–5)
+  const comparable = rated.filter((movie) => movie.tomatoMeter != null)
+  const yourAvg =
+    comparable.length > 0
+      ? Math.round(
+          (comparable.reduce((sum, movie) => sum + (movie.userRating || 0), 0) /
+            comparable.length) *
+            20
+        )
+      : null
+  const criticsAvg =
+    comparable.length > 0
+      ? Math.round(
+          comparable.reduce((sum, movie) => sum + (movie.tomatoMeter || 0), 0) /
+            comparable.length
+        )
+      : null
+  const delta = yourAvg != null && criticsAvg != null ? yourAvg - criticsAvg : null
+
+  // Most-watched director among rated movies
+  const directorCounts = new Map<string, number>()
+  for (const movie of rated) {
+    const director = movie.directedBy?.trim()
+    if (director) {
+      directorCounts.set(director, (directorCounts.get(director) || 0) + 1)
+    }
+  }
+  const topDirector = [...directorCounts.entries()].sort(
+    (a, b) => b[1] - a[1]
+  )[0]
+
+  const statTiles = [
+    minutesWatched > 0 && {
+      label: 'Hours watched',
+      value: formatHours(minutesWatched),
+      detail: `${rated.length} ${rated.length === 1 ? 'movie' : 'movies'} rated`,
+    },
+    delta != null && {
+      label: 'You vs critics',
+      value: delta === 0 ? 'Even' : `${delta > 0 ? '+' : ''}${delta}%`,
+      detail:
+        delta === 0
+          ? 'You agree with the critics'
+          : delta > 0
+            ? 'More generous than critics 🍿'
+            : 'Tougher than the critics 🧐',
+    },
+    topDirector && {
+      label: 'Top director',
+      value: topDirector[0].split(',')[0] ?? topDirector[0],
+      detail: `${topDirector[1]} ${topDirector[1] === 1 ? 'movie' : 'movies'} seen`,
+      small: true,
+    },
+  ].filter(Boolean) as {
+    label: string
+    value: string
+    detail: string
+    small?: boolean
+  }[]
+
+  return (
+    <section aria-label="Your taste in numbers" className="mb-10">
+      <h2 className="section-heading mb-4">
+        <span className="gradient-text">Your taste</span>
+      </h2>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        {/* KPI tiles */}
+        {statTiles.map((tile) => (
+          <div key={tile.label} className="surface p-5">
+            <p className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
+              {tile.label}
+            </p>
+            <p
+              className={`mt-1 font-heading font-bold text-white ${
+                tile.small ? 'truncate text-2xl' : 'text-4xl'
+              }`}
+            >
+              {tile.value}
+            </p>
+            <p className="mt-1 text-sm text-zinc-400">{tile.detail}</p>
+          </div>
+        ))}
+
+        {/* Favorite genres — single-series horizontal bars, direct-labeled */}
+        {topGenres.length > 0 && (
+          <div className="surface p-5 md:col-span-2">
+            <p className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
+              Favorite genres
+            </p>
+            <ul className="mt-3 flex flex-col gap-2.5">
+              {topGenres.map(([genre, count]) => (
+                <li
+                  key={genre}
+                  className="flex items-center gap-3"
+                  title={`${genre} — ${count} ${count === 1 ? 'movie' : 'movies'}`}
+                >
+                  <span className="w-28 shrink-0 truncate text-sm text-zinc-300">
+                    {genre}
+                  </span>
+                  <span className="relative h-3 flex-1 overflow-hidden rounded-full bg-zinc-800">
+                    <span
+                      className="absolute inset-y-0 left-0 rounded-full"
+                      style={{
+                        width: `${Math.max((count / maxGenreCount) * 100, 6)}%`,
+                        backgroundColor: YOU_COLOR,
+                      }}
+                    />
+                  </span>
+                  <span className="w-6 shrink-0 text-right text-sm tabular-nums text-zinc-400">
+                    {count}
+                  </span>
+                </li>
+              ))}
+              {otherCount > 0 && (
+                <li className="flex items-center gap-3 text-zinc-500">
+                  <span className="w-28 shrink-0 text-sm">Other</span>
+                  <span className="relative h-3 flex-1 overflow-hidden rounded-full bg-zinc-800">
+                    <span
+                      className="absolute inset-y-0 left-0 rounded-full bg-zinc-600"
+                      style={{
+                        width: `${Math.max((otherCount / maxGenreCount) * 100, 6)}%`,
+                      }}
+                    />
+                  </span>
+                  <span className="w-6 shrink-0 text-right text-sm tabular-nums">
+                    {otherCount}
+                  </span>
+                </li>
+              )}
+            </ul>
+          </div>
+        )}
+
+        {/* You vs critics — two direct-labeled bars on the same 0–100 scale */}
+        {yourAvg != null && criticsAvg != null && (
+          <div className="surface p-5">
+            <p className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
+              Average score
+            </p>
+            <ul className="mt-3 flex flex-col gap-3">
+              {[
+                { label: 'You', value: yourAvg, color: YOU_COLOR },
+                { label: 'Critics', value: criticsAvg, color: CRITICS_COLOR },
+              ].map((row) => (
+                <li key={row.label}>
+                  <div className="mb-1 flex items-center justify-between text-sm">
+                    <span className="flex items-center gap-2 text-zinc-300">
+                      <span
+                        aria-hidden
+                        className="h-2.5 w-2.5 rounded-full"
+                        style={{ backgroundColor: row.color }}
+                      />
+                      {row.label}
+                    </span>
+                    <span className="tabular-nums text-zinc-400">
+                      {row.value}%
+                    </span>
+                  </div>
+                  <div
+                    className="relative h-3 overflow-hidden rounded-full bg-zinc-800"
+                    title={`${row.label}: ${row.value}%`}
+                  >
+                    <span
+                      className="absolute inset-y-0 left-0 rounded-full"
+                      style={{
+                        width: `${row.value}%`,
+                        backgroundColor: row.color,
+                      }}
+                    />
+                  </div>
+                </li>
+              ))}
+            </ul>
+            <p className="mt-3 text-xs text-zinc-500">
+              Across {comparable.length} rated{' '}
+              {comparable.length === 1 ? 'movie' : 'movies'} with a Tomatometer
+            </p>
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
+export default ProfileStats

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,25 +1,64 @@
 'use client'
 
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { FC } from 'react'
 import type { SearchProps } from './types'
-import { HiOutlineSearch, HiX } from 'react-icons/hi'
+import { HiOutlineSearch, HiX, HiOutlineClock } from 'react-icons/hi'
 import { CgSpinner } from 'react-icons/cg'
 
-const Search: FC<SearchProps> = ({ loading, onQueryChange }) => {
-  const [value, setValue] = useState('')
-  const inputRef = useRef<HTMLInputElement>(null)
+export const RECENT_SEARCHES_KEY = 'movie-fan-recent-searches'
+const MAX_RECENTS = 6
 
-  const handleChange = (next: string) => {
-    setValue(next)
-    onQueryChange(next)
+export const readRecentSearches = (): string[] => {
+  if (typeof window === 'undefined') return []
+  try {
+    const parsed = JSON.parse(localStorage.getItem(RECENT_SEARCHES_KEY) || '[]')
+    return Array.isArray(parsed) ? parsed.filter((s) => typeof s === 'string') : []
+  } catch {
+    return []
   }
+}
+
+export const saveRecentSearch = (query: string) => {
+  const next = [
+    query,
+    ...readRecentSearches().filter(
+      (item) => item.toLowerCase() !== query.toLowerCase()
+    ),
+  ].slice(0, MAX_RECENTS)
+  try {
+    localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(next))
+  } catch {
+    /* storage full or blocked — recents are a nice-to-have */
+  }
+}
+
+const Search: FC<SearchProps> = ({ value, loading, onQueryChange }) => {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [focused, setFocused] = useState(false)
+  const [recents, setRecents] = useState<string[]>([])
+
+  // "/" anywhere on the page jumps to search (like GitHub/YouTube)
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== '/' || e.metaKey || e.ctrlKey || e.altKey) return
+      const target = e.target as HTMLElement | null
+      const tag = target?.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable)
+        return
+      e.preventDefault()
+      inputRef.current?.focus()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
 
   const clear = () => {
-    setValue('')
     onQueryChange('')
     inputRef.current?.focus()
   }
+
+  const showRecents = focused && value === '' && recents.length > 0
 
   return (
     <div className="relative mx-auto w-full max-w-2xl">
@@ -31,29 +70,74 @@ const Search: FC<SearchProps> = ({ loading, onQueryChange }) => {
       </label>
       <input
         ref={inputRef}
-        className="w-full rounded-full border border-zinc-700 bg-zinc-900/80 py-3 pl-12 pr-12 text-lg text-white placeholder-zinc-500 shadow-lg outline-none transition focus:border-pink-500 focus:ring-2 focus:ring-pink-500/40"
+        className="w-full rounded-full border border-zinc-700 bg-zinc-900/80 py-3 pl-12 pr-16 text-lg text-white placeholder-zinc-500 shadow-lg outline-none transition focus:border-pink-500 focus:ring-2 focus:ring-pink-500/40"
         value={value}
-        onChange={(e) => handleChange(e.target.value)}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onFocus={() => {
+          setRecents(readRecentSearches())
+          setFocused(true)
+        }}
+        onBlur={() => setFocused(false)}
         id="search"
         placeholder="Search for movies"
         type="search"
         autoComplete="off"
       />
-      <span className="absolute right-4 top-1/2 -translate-y-1/2">
+      <span className="absolute right-4 top-1/2 flex -translate-y-1/2 items-center gap-2">
         {loading ? (
           <CgSpinner className="h-5 w-5 animate-spin text-pink-500" />
+        ) : value ? (
+          <button
+            onClick={clear}
+            aria-label="Clear search"
+            className="text-zinc-400 transition hover:text-white"
+          >
+            <HiX className="h-5 w-5" />
+          </button>
         ) : (
-          value && (
-            <button
-              onClick={clear}
-              aria-label="Clear search"
-              className="text-zinc-400 transition hover:text-white"
-            >
-              <HiX className="h-5 w-5" />
-            </button>
-          )
+          <kbd className="hidden rounded border border-zinc-700 bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-400 sm:block">
+            /
+          </kbd>
         )}
       </span>
+
+      {/* Recent searches — shown on focus while the box is empty */}
+      {showRecents && (
+        <div className="absolute inset-x-0 top-full z-30 mt-2 overflow-hidden rounded-2xl border border-zinc-800 bg-zinc-900/95 shadow-2xl backdrop-blur">
+          <div className="flex items-center justify-between px-4 pb-1 pt-3">
+            <p className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
+              Recent searches
+            </p>
+            <button
+              // mousedown so it wins the race against the input's blur
+              onMouseDown={(e) => {
+                e.preventDefault()
+                localStorage.removeItem(RECENT_SEARCHES_KEY)
+                setRecents([])
+              }}
+              className="text-xs text-zinc-500 transition hover:text-pink-400"
+            >
+              Clear
+            </button>
+          </div>
+          <ul className="pb-2">
+            {recents.map((recent) => (
+              <li key={recent}>
+                <button
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    onQueryChange(recent)
+                  }}
+                  className="flex w-full items-center gap-3 px-4 py-2 text-left text-zinc-200 transition hover:bg-zinc-800/80 hover:text-pink-400"
+                >
+                  <HiOutlineClock className="h-4 w-4 shrink-0 text-zinc-500" />
+                  <span className="truncate">{recent}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/Search/types.d.ts
+++ b/src/components/Search/types.d.ts
@@ -1,4 +1,5 @@
 export interface SearchProps {
+  value: string;
   onQueryChange: (value: string) => void;
   loading: boolean;
 }

--- a/src/components/StarRating/StarRating.tsx
+++ b/src/components/StarRating/StarRating.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import type { CSSProperties } from 'react'
 
 interface StarRatingProps {
   value?: number
@@ -8,12 +9,29 @@ interface StarRatingProps {
   size?: number
 }
 
+// A small, dependency-free burst of particles for the 5-star moment
+const CONFETTI_COLORS = ['#ec4899', '#f43f5e', '#facc15', '#38bdf8', '#a78bfa']
+const CONFETTI_PIECES = 14
+
 const StarRating = ({ value = 0, onChange, size = 32 }: StarRatingProps) => {
   const [hover, setHover] = useState(0)
+  const [burst, setBurst] = useState(0)
   const active = hover || value
 
+  const handleClick = (n: number) => {
+    onChange?.(n)
+    // Celebrate a perfect score, unless the user prefers reduced motion
+    if (
+      n === 5 &&
+      !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    ) {
+      // key bump restarts the animation even on repeat 5-star clicks
+      setBurst((b) => b + 1)
+    }
+  }
+
   return (
-    <div className="flex" onMouseLeave={() => setHover(0)}>
+    <div className="relative flex" onMouseLeave={() => setHover(0)}>
       {[1, 2, 3, 4, 5].map((n) => (
         <button
           key={n}
@@ -21,7 +39,7 @@ const StarRating = ({ value = 0, onChange, size = 32 }: StarRatingProps) => {
           aria-label={`Rate ${n} star${n > 1 ? 's' : ''}`}
           onMouseEnter={() => setHover(n)}
           onFocus={() => setHover(n)}
-          onClick={() => onChange?.(n)}
+          onClick={() => handleClick(n)}
           className="px-0.5 leading-none transition-transform hover:scale-110"
         >
           <span
@@ -32,6 +50,34 @@ const StarRating = ({ value = 0, onChange, size = 32 }: StarRatingProps) => {
           </span>
         </button>
       ))}
+
+      {burst > 0 && (
+        <div
+          key={burst}
+          aria-hidden
+          className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center"
+        >
+          {Array.from({ length: CONFETTI_PIECES }).map((_, i) => {
+            const angle = (360 / CONFETTI_PIECES) * i
+            const distance = 26 + (i % 4) * 10
+            const tx = Math.cos((angle * Math.PI) / 180) * distance
+            const ty = Math.sin((angle * Math.PI) / 180) * distance
+            return (
+              <span
+                key={i}
+                className="confetti-piece absolute h-1.5 w-1.5 rounded-sm"
+                style={
+                  {
+                    backgroundColor: CONFETTI_COLORS[i % CONFETTI_COLORS.length],
+                    '--tx': `${tx}px`,
+                    '--ty': `${ty}px`,
+                  } as CSSProperties
+                }
+              />
+            )
+          })}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/hooks/useWatchlist.ts
+++ b/src/hooks/useWatchlist.ts
@@ -1,0 +1,58 @@
+'use client'
+
+/**
+ * Session-aware watchlist state shared by movie cards and the hero.
+ * Exposes membership lookups plus a one-click toggle backed by the
+ * movie.quickAdd / movie.delete mutations. Signed-out users are sent
+ * to the sign-in flow instead.
+ */
+import { useSession, signIn } from 'next-auth/react'
+import { api } from '@/utils/api'
+
+export const useWatchlist = () => {
+  const { data: session } = useSession()
+  const utils = api.useUtils()
+
+  const watchlist = api.user.query.useQuery(undefined, {
+    enabled: !!session,
+    staleTime: 30_000,
+  })
+
+  const invalidate = () => {
+    utils.user.query.invalidate()
+    utils.movie.query.invalidate()
+  }
+
+  const quickAdd = api.movie.quickAdd.useMutation({ onSuccess: invalidate })
+  const remove = api.movie.delete.useMutation({ onSuccess: invalidate })
+
+  const ids = new Set(
+    (watchlist.data?.movies ?? []).map((movie) => movie.movieId)
+  )
+
+  const has = (movieId: string) => ids.has(movieId)
+
+  const toggle = (movieId: string) => {
+    if (!session) {
+      signIn()
+      return
+    }
+    if (has(movieId)) {
+      remove.mutate({ movieId })
+    } else {
+      quickAdd.mutate({ movieId })
+    }
+  }
+
+  return {
+    isSignedIn: !!session,
+    has,
+    toggle,
+    // Lets a card show a spinner only for the movie actually being toggled
+    pendingId: quickAdd.isPending
+      ? quickAdd.variables?.movieId
+      : remove.isPending
+        ? remove.variables?.movieId
+        : null,
+  }
+}

--- a/src/server/api/routers/watchListItem.ts
+++ b/src/server/api/routers/watchListItem.ts
@@ -2,8 +2,57 @@ import { TRPCError } from '@trpc/server';
 import { MovieSchema } from '@/types/MovieSchema';
 import { z } from 'zod';
 import { createTRPCRouter, protectedProcedure } from './../trpc';
+import { fetchDetails } from '@/server/flixster';
+import { createMovieObj } from '@/utils/createMovieObj';
+import type { IMovieDetail } from '@/components/MovieDetails/types';
 
 export const watchListItemRouter = createTRPCRouter({
+  /**
+   * One-click add from a movie card: the client only knows the emsVersionId,
+   * so the server fetches full details itself and upserts the row. On update
+   * the user's existing star rating is preserved (quick-add never clears it).
+   */
+  quickAdd: protectedProcedure
+    .input(z.object({ movieId: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const { prisma, session } = ctx;
+      const userId = session.user.id;
+
+      const movie = (await fetchDetails(input.movieId).catch(() => null)) as
+        | IMovieDetail
+        | null;
+      if (!movie) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Could not load movie details',
+        });
+      }
+
+      const genres = (movie.genres || []).map((genre) => genre.name);
+      const movieData = createMovieObj(movie, input.movieId, genres);
+      // Don't touch userRating on update — quick-add is not a rating action,
+      // so an existing star rating must survive
+      const updateFields: Partial<typeof movieData> = { ...movieData };
+      delete updateFields.userRating;
+
+      try {
+        return await prisma.watchListItem.upsert({
+          where: {
+            userId_movieId: { userId, movieId: input.movieId },
+          },
+          update: updateFields,
+          create: {
+            ...movieData,
+            user: { connect: { id: userId } },
+          },
+        });
+      } catch {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to save movie to watchlist',
+        });
+      }
+    }),
   create: protectedProcedure.input(z.object({
     movieData: MovieSchema
   }))

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -74,3 +74,27 @@
 .grid-credit-cards {
   grid-template-columns: repeat(auto-fit, 196px);
 }
+
+/* Confetti burst for a 5-star rating (StarRating). Each piece flies out to
+   its own --tx/--ty offset and fades. */
+.confetti-piece {
+  animation: confetti-fly 700ms ease-out forwards;
+}
+
+@keyframes confetti-fly {
+  0% {
+    opacity: 1;
+    transform: translate(0, 0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(var(--tx), var(--ty)) scale(0.4) rotate(200deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .confetti-piece {
+    animation: none;
+    display: none;
+  }
+}

--- a/src/utils/createMovieObj.ts
+++ b/src/utils/createMovieObj.ts
@@ -1,20 +1,22 @@
 import type { IMovieDetail } from "@/components/MovieDetails/types"
 import type { MovieType } from "@/types/MovieSchema"
 
-export const createMovieObj = (movie: IMovieDetail, id: string, genres: string[], userRating:number | null = null) => { 
+export const createMovieObj = (movie: IMovieDetail, id: string, genres: string[], userRating:number | null = null) => {
    const movieData: MovieType = {
       movieId: id,
       name: movie.name,
-      synopsis: movie.synopsis,
+      synopsis: movie.synopsis ?? null,
       consensus: movie.tomatoRating?.consensus || null,
-      durationMinutes: movie.durationMinutes,
-      releaseDate: movie.releaseDate,
-      directedBy: movie.directedBy,
+      // Defensive fallbacks: quickAdd builds this object server-side from a raw
+      // API payload, where any of these fields can be absent
+      durationMinutes: movie.durationMinutes ?? 0,
+      releaseDate: movie.releaseDate ?? '',
+      directedBy: movie.directedBy ?? '',
       genres: genres,
       emsVersionId: movie.emsVersionId || id,
-      posterImage: movie.posterImage.url,
+      posterImage: movie.posterImage?.url ?? '',
       tomatoMeter: movie.tomatoRating?.tomatometer || null,
-      totalGross: movie.totalGross,
+      totalGross: movie.totalGross ?? null,
       motionPictureRating: movie.motionPictureRating?.code || 'Not Rated',
       userRating: userRating,
     }


### PR DESCRIPTION
## Summary
Builds on the merged homepage layout (PR #16) with a broad round of interactivity and information-density improvements, surfacing data the app already fetches/stores but never displayed.

## Homepage
- **Rotating hero** — cycles the top 5 popular movies (auto-advance with pause-on-hover on hover-capable devices, dots + arrows, `prefers-reduced-motion` aware) and gains a one-click watchlist button. Compact vertical rhythm so it sits well beside News on large screens; rotation works on touch devices (taps no longer freeze it).
- **"Top 10 today"** row with Netflix-style rank numerals.
- **Quick-add hearts** and a richer hover treatment on movie cards, backed by a shared `useWatchlist` hook and a new `movie.quickAdd` tRPC mutation that fetches details server-side (so a card only needs the id, and an existing star rating is preserved on update).

## Search
- Controlled input with a `/` focus shortcut, a recent-searches dropdown (localStorage), and a `?q=` deep link.

## Movie details
- **Details facts panel** (release date, runtime, director, box office, full MPAA rating) — data that was stored but never shown.
- **Theater + showtimes list** (defensive parsing) instead of just a count.
- Photo gallery opens a keyboard-navigable **lightbox**.
- **Share** button (Web Share API with clipboard fallback).

## People pages (new)
- Cast/crew cards open an **in-app `/person/[name]` profile**: portrait, bio with read-more, life facts, and a most-popular-first filmography grid, powered by TMDB's person endpoints.
- Filmography clicks route through **`/api/find-movie`**, which resolves the title/year back to a Flixster `emsVersionId` via the existing search API and redirects to the in-app movie page (in-app search as fallback). Plain anchors (not `next/link`) so viewport prefetching can't burn API quota.
- New optional **`TMDB_API_KEY`** env var (v3 key or v4 bearer token). Without it, person pages degrade to an external Rotten Tomatoes search link.

## Profile
- **"Your taste" dashboard**: favorite-genre bars, hours watched, you-vs-critics average, and top director — all computed from existing watchlist rows (colorblind-validated pink/sky palette, direct-labeled).
- **Genre filter chips** on the watchlist/seen grids.

## Polish
- News section gains a **"More news"** expander; Hollywood Reporter + Deadline image hosts whitelisted (fixes broken featured images) with a fallback when a feed image is dead.
- Nav keeps the avatar everywhere with a **Profile / Sign-out dropdown**.
- 5-star ratings trigger a dependency-free **confetti burst**.

## Verification note
Automated typecheck/lint/build could not be run in the authoring environment (dependency install failed against the registry, no `node_modules`). Changes were reviewed manually; please rely on CI here for the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)