### PR TITLE
Fix hero/news/cast issues, add in-app people pages via TMDB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,8 @@ EMAIL_FROM=
 
 # Movie data (RapidAPI)
 RAPID_API_KEY=
+
+# People pages (optional) — TMDB API key or v4 read access token.
+# Free at https://www.themoviedb.org/settings/api. Without it, cast
+# clicks fall back to an external Rotten Tomatoes search.
+TMDB_API_KEY=

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,7 +14,10 @@ const imageHosts = [
   'lh3.googleusercontent.com',
   'raw.githubusercontent.com',
   'avatars.githubusercontent.com',
+  // News RSS feed image hosts (see src/server/news.ts FEEDS)
   'variety.com',
+  'www.hollywoodreporter.com',
+  'deadline.com',
 ];
 
 /** @type {import("next").NextConfig} */

--- a/src/app/api/find-movie/route.ts
+++ b/src/app/api/find-movie/route.ts
@@ -1,0 +1,56 @@
+/**
+ * Bridges TMDB filmography items back onto this app's Flixster-keyed movie
+ * pages: search Flixster by title, pick the best match (exact title + year,
+ * then exact title, then first hit), and redirect to /movie/<emsVersionId>.
+ * When nothing matches, fall back to the in-app search for the title so the
+ * user still lands somewhere useful.
+ */
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { fetchSearch } from '@/server/flixster'
+
+const normalize = (value: string) => value.trim().toLowerCase()
+
+type SearchHit = {
+  emsVersionId?: string
+  name?: string
+  releaseDate?: string
+}
+
+export async function GET(request: NextRequest) {
+  const title = request.nextUrl.searchParams.get('title')?.trim()
+  const year = request.nextUrl.searchParams.get('year')?.trim()
+
+  if (!title) {
+    return NextResponse.redirect(new URL('/', request.url))
+  }
+
+  const searchFallback = new URL(
+    `/?q=${encodeURIComponent(title)}`,
+    request.url
+  )
+
+  let hits: SearchHit[] = []
+  try {
+    hits = ((await fetchSearch(title)) as SearchHit[]).filter(
+      (hit) => hit.emsVersionId && hit.name
+    )
+  } catch {
+    return NextResponse.redirect(searchFallback)
+  }
+
+  const wanted = normalize(title)
+  const exact = hits.filter((hit) => normalize(hit.name!) === wanted)
+  const best =
+    (year && exact.find((hit) => hit.releaseDate?.startsWith(year))) ||
+    exact[0] ||
+    hits[0]
+
+  if (!best) {
+    return NextResponse.redirect(searchFallback)
+  }
+
+  return NextResponse.redirect(
+    new URL(`/movie/${best.emsVersionId}`, request.url)
+  )
+}

--- a/src/app/person/[name]/loading.tsx
+++ b/src/app/person/[name]/loading.tsx
@@ -1,0 +1,24 @@
+export default function Loading() {
+  return (
+    <main className="mx-auto max-w-screen-xl animate-pulse px-4 pb-16 sm:px-8">
+      <div className="flex flex-col items-center gap-6 py-10 sm:flex-row sm:items-start sm:gap-10">
+        <div className="aspect-[2/3] w-40 shrink-0 rounded-xl bg-zinc-800 sm:w-52" />
+        <div className="flex w-full max-w-2xl flex-col items-center gap-4 sm:items-start">
+          <div className="h-10 w-64 rounded-lg bg-zinc-800" />
+          <div className="h-6 w-80 max-w-full rounded-full bg-zinc-800" />
+          <div className="h-4 w-full rounded bg-zinc-800" />
+          <div className="h-4 w-full rounded bg-zinc-800" />
+          <div className="h-4 w-2/3 rounded bg-zinc-800" />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+        {Array.from({ length: 12 }).map((_, idx) => (
+          <div key={idx}>
+            <div className="aspect-[2/3] rounded-xl bg-zinc-800" />
+            <div className="mt-2 h-4 w-3/4 rounded bg-zinc-800" />
+          </div>
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/src/app/person/[name]/page.tsx
+++ b/src/app/person/[name]/page.tsx
@@ -1,0 +1,173 @@
+import type { Metadata } from 'next'
+import Image from 'next/image'
+import Link from 'next/link'
+
+import { fetchPerson, isTmdbConfigured } from '@/server/tmdb'
+
+// People data barely changes — rebuild at most daily
+export const revalidate = 86400
+
+const MAX_CREDITS = 18
+
+type PageProps = { params: Promise<{ name: string }> }
+
+const rtSearchUrl = (name: string) =>
+  `https://www.rottentomatoes.com/search?search=${encodeURIComponent(name)}`
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { name } = await params
+  const decoded = decodeURIComponent(name)
+  return {
+    title: decoded,
+    description: `Movies featuring ${decoded}`,
+  }
+}
+
+export default async function PersonPage({ params }: PageProps) {
+  const { name } = await params
+  const decoded = decodeURIComponent(name)
+
+  const person = isTmdbConfigured()
+    ? await fetchPerson(decoded).catch(() => null)
+    : null
+
+  if (!person) {
+    return (
+      <main className="mx-auto max-w-screen-md px-4 py-24 text-center text-white sm:px-8">
+        <h1 className="font-heading text-3xl font-bold sm:text-4xl">
+          {decoded}
+        </h1>
+        <p className="mt-4 text-zinc-400">
+          We couldn&apos;t load a profile for this person right now.
+        </p>
+        <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+          <a
+            href={rtSearchUrl(decoded)}
+            target="_blank"
+            rel="noreferrer"
+            className="btn-brand"
+          >
+            Find them on Rotten Tomatoes
+          </a>
+          <Link href="/" className="btn-ghost">
+            Back to home
+          </Link>
+        </div>
+      </main>
+    )
+  }
+
+  const facts = [
+    person.knownForDepartment && `Known for ${person.knownForDepartment}`,
+    person.birthday &&
+      `Born ${person.birthday}${person.deathday ? ` — died ${person.deathday}` : ''}`,
+    person.placeOfBirth,
+  ].filter(Boolean) as string[]
+
+  const bioParagraphs = (person.biography || '')
+    .split(/\n+/)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean)
+
+  const credits = person.credits.slice(0, MAX_CREDITS)
+
+  return (
+    <main className="mx-auto max-w-screen-xl px-4 pb-16 text-white sm:px-8">
+      {/* Profile header */}
+      <div className="flex flex-col items-center gap-6 py-10 sm:flex-row sm:items-start sm:gap-10">
+        <div className="relative aspect-[2/3] w-40 shrink-0 overflow-hidden rounded-xl border border-zinc-700 shadow-2xl sm:w-52">
+          <Image
+            src={person.profileUrl || '/Default-Avatar.png'}
+            fill
+            priority
+            sizes="(max-width: 640px) 45vw, 210px"
+            alt={`${person.name} portrait`}
+            className="object-cover"
+          />
+        </div>
+
+        <div className="text-center sm:text-left">
+          <h1 className="font-heading text-3xl font-bold sm:text-5xl">
+            {person.name}
+          </h1>
+
+          {facts.length > 0 && (
+            <div className="mt-4 flex flex-wrap justify-center gap-2 sm:justify-start">
+              {facts.map((fact) => (
+                <span key={fact} className="chip">
+                  {fact}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {bioParagraphs.length > 0 && (
+            <div className="mt-5 max-w-2xl space-y-3 text-left leading-relaxed text-zinc-300">
+              {bioParagraphs.slice(0, 2).map((paragraph, idx) => (
+                <p key={idx}>{paragraph}</p>
+              ))}
+              {bioParagraphs.length > 2 && (
+                <details className="group">
+                  <summary className="cursor-pointer list-none text-sm font-semibold text-pink-400 transition hover:text-pink-300">
+                    <span className="group-open:hidden">Read full bio</span>
+                    <span className="hidden group-open:inline">Show less</span>
+                  </summary>
+                  <div className="mt-3 space-y-3">
+                    {bioParagraphs.slice(2).map((paragraph, idx) => (
+                      <p key={idx}>{paragraph}</p>
+                    ))}
+                  </div>
+                </details>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Filmography */}
+      {credits.length > 0 && (
+        <section>
+          <h2 className="section-heading mb-4">
+            <span className="gradient-text">Known for</span>
+          </h2>
+          <div className="grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+            {credits.map((credit) => (
+              // Plain <a>, not <Link>: the href is a resolver API route that
+              // hits the Flixster search — Link prefetching would burn quota
+              // for every card that scrolls into view
+              <a
+                key={credit.tmdbId}
+                href={`/api/find-movie?title=${encodeURIComponent(credit.title)}${
+                  credit.year ? `&year=${credit.year}` : ''
+                }`}
+                className="group block"
+              >
+                <div className="relative aspect-[2/3] overflow-hidden rounded-xl border border-zinc-800 bg-zinc-900 shadow-lg transition duration-300 group-hover:border-zinc-600 group-hover:shadow-pink-900/20">
+                  <Image
+                    src={credit.posterUrl || '/placeholderposter.png'}
+                    fill
+                    sizes="(max-width: 640px) 45vw, 180px"
+                    alt={`${credit.title} poster`}
+                    className="object-cover transition duration-300 group-hover:scale-105"
+                  />
+                </div>
+                <div className="mt-2 px-0.5">
+                  <p className="truncate font-heading text-sm font-semibold text-white transition group-hover:text-pink-400">
+                    {credit.title}
+                  </p>
+                  <p className="truncate text-xs text-zinc-500">
+                    {[credit.year, credit.character && `as ${credit.character}`]
+                      .filter(Boolean)
+                      .join(' · ')}
+                  </p>
+                </div>
+              </a>
+            ))}
+          </div>
+        </section>
+      )}
+    </main>
+  )
+}

--- a/src/components/CastCard/CastCard.tsx
+++ b/src/components/CastCard/CastCard.tsx
@@ -1,7 +1,6 @@
 import type { FC } from 'react'
 import type { CastCardProps } from './types'
 import Image from 'next/image'
-import Link from 'next/link'
 
 const CastCard: FC<CastCardProps> = ({
   role,
@@ -31,16 +30,19 @@ const CastCard: FC<CastCardProps> = ({
     </>
   )
 
-  // Clicking a person searches their name — an easy way to find their other movies
+  // The in-app search only matches movie titles, so a person's name would
+  // find nothing — link to Rotten Tomatoes' people search instead
   if (name) {
     return (
-      <Link
-        href={`/?q=${encodeURIComponent(name)}`}
-        title={`Search for ${name}`}
+      <a
+        href={`https://www.rottentomatoes.com/search?search=${encodeURIComponent(name)}`}
+        target="_blank"
+        rel="noreferrer"
+        title={`Find ${name} on Rotten Tomatoes`}
         className="group w-28 shrink-0 text-center sm:w-full"
       >
         {card}
-      </Link>
+      </a>
     )
   }
 

--- a/src/components/CastCard/CastCard.tsx
+++ b/src/components/CastCard/CastCard.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react'
 import type { CastCardProps } from './types'
 import Image from 'next/image'
+import Link from 'next/link'
 
 const CastCard: FC<CastCardProps> = ({
   role,
@@ -30,19 +31,16 @@ const CastCard: FC<CastCardProps> = ({
     </>
   )
 
-  // The in-app search only matches movie titles, so a person's name would
-  // find nothing — link to Rotten Tomatoes' people search instead
+  // Clicking a person opens their in-app profile with a filmography
   if (name) {
     return (
-      <a
-        href={`https://www.rottentomatoes.com/search?search=${encodeURIComponent(name)}`}
-        target="_blank"
-        rel="noreferrer"
-        title={`Find ${name} on Rotten Tomatoes`}
+      <Link
+        href={`/person/${encodeURIComponent(name)}`}
+        title={`See movies with ${name}`}
         className="group w-28 shrink-0 text-center sm:w-full"
       >
         {card}
-      </a>
+      </Link>
     )
   }
 

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -45,10 +45,16 @@ const Hero: FC<HeroProps> = ({ movies }) => {
 
   if (slides.length === 0) return null
 
+  // Only hover-capable devices pause on mouseenter — mobile taps also fire
+  // mouseenter but never mouseleave, which froze the rotation on touch
+  const pauseIfHoverDevice = () => {
+    if (window.matchMedia('(hover: hover)').matches) setPaused(true)
+  }
+
   return (
     <section
       className="group/hero relative h-full overflow-hidden rounded-2xl"
-      onMouseEnter={() => setPaused(true)}
+      onMouseEnter={pauseIfHoverDevice}
       onMouseLeave={() => setPaused(false)}
       aria-roledescription="carousel"
       aria-label="Popular movies spotlight"
@@ -88,28 +94,28 @@ const Hero: FC<HeroProps> = ({ movies }) => {
               <div className="absolute inset-0 bg-gradient-to-t from-black via-black/70 to-transparent" />
             </div>
 
-            <div className="relative mx-auto flex max-w-screen-xl flex-col items-center gap-6 px-4 py-10 pb-14 sm:flex-row sm:items-end sm:px-8 sm:py-16 sm:pb-16">
-              <div className="relative aspect-[2/3] w-36 shrink-0 overflow-hidden rounded-xl border border-zinc-700 shadow-2xl sm:w-52">
+            <div className="relative mx-auto flex max-w-screen-xl flex-col items-center gap-5 px-4 py-8 pb-12 sm:flex-row sm:items-end sm:px-8 sm:py-10 sm:pb-12">
+              <div className="relative aspect-[2/3] w-28 shrink-0 overflow-hidden rounded-xl border border-zinc-700 shadow-2xl sm:w-40">
                 <Image
                   src={poster}
                   fill
                   priority={i === 0}
-                  sizes="(max-width: 640px) 40vw, 210px"
+                  sizes="(max-width: 640px) 30vw, 160px"
                   alt={`${movie.name} poster`}
                   className="object-cover"
                 />
               </div>
               <div className="text-center sm:text-left">
-                <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-pink-400">
+                <p className="mb-1.5 text-xs font-semibold uppercase tracking-[0.2em] text-pink-400">
                   #{i + 1} Popular
                 </p>
-                <h2 className="font-heading text-3xl font-bold text-white sm:text-5xl">
+                <h2 className="font-heading text-2xl font-bold text-white sm:text-3xl xl:text-4xl">
                   {movie.name}
                 </h2>
                 {score != null && (
-                  <p className="chip mt-4 text-base">🍅 {score}%</p>
+                  <p className="chip mt-3 text-sm">🍅 {score}%</p>
                 )}
-                <div className="mt-6 flex flex-wrap items-center justify-center gap-3 sm:justify-start">
+                <div className="mt-4 flex flex-wrap items-center justify-center gap-3 sm:justify-start">
                   <Link
                     href={`/movie/${movie.emsVersionId}`}
                     className="btn-brand"

--- a/src/components/News/News.tsx
+++ b/src/components/News/News.tsx
@@ -13,10 +13,15 @@ const INITIAL_STORIES = 8
 
 const News: FC<NewsStoryProps> = ({ newsStories }) => {
   const [expanded, setExpanded] = useState(false)
+  // Feed images can 404 or come from a host we can't render — when one
+  // fails, fall back to the next story that has a working image
+  const [failedImages, setFailedImages] = useState<Set<string>>(new Set())
   const stories = (newsStories || []).filter(
     (story) => !story.title?.toLowerCase().includes('tv')
   )
-  const mainStory = stories.find((story) => story.mainImage?.url)
+  const mainStory = stories.find(
+    (story) => story.mainImage?.url && !failedImages.has(story.mainImage.url)
+  )
   const restStories = stories.filter((story) => story.id !== mainStory?.id)
   const visibleStories = expanded
     ? restStories
@@ -48,6 +53,11 @@ const News: FC<NewsStoryProps> = ({ newsStories }) => {
                 sizes="(max-width: 1024px) 100vw, 600px"
                 alt="Featured news story"
                 className="object-cover transition duration-300 group-hover:scale-105"
+                onError={() =>
+                  setFailedImages(
+                    (prev) => new Set(prev).add(mainStory.mainImage.url)
+                  )
+                }
               />
             </div>
             <Balancer className="block p-4 text-lg font-semibold transition group-hover:text-pink-400 lg:text-xl">

--- a/src/env/schema.mjs
+++ b/src/env/schema.mjs
@@ -31,6 +31,9 @@ export const serverSchema = z.object({
   FACEBOOK_CLIENT_ID: z.string(),
   FACEBOOK_CLIENT_SECRET: z.string(),
   RAPID_API_KEY: z.string().min(1),
+  // Optional: powers the in-app people pages (/person/...). Without it,
+  // those pages degrade to an external Rotten Tomatoes search link.
+  TMDB_API_KEY: z.string().optional(),
 })
 
 /**

--- a/src/server/tmdb.ts
+++ b/src/server/tmdb.ts
@@ -1,0 +1,121 @@
+/**
+ * Server-only TMDB fetchers powering the in-app people pages. TMDB is used
+ * solely for person data (the Flixster API has no people endpoint); movie
+ * detail pages stay on Flixster ids via the /api/find-movie resolver.
+ *
+ * Supports both TMDB credential styles: a v3 api key (query param) and a
+ * v4 read access token (Bearer header — those are JWTs starting "eyJ").
+ */
+import { env } from '../env/server.mjs'
+import { TMDB_BASE_API_URL } from '@/data/Constants'
+
+const POSTER_BASE = 'https://image.tmdb.org/t/p/w342'
+const PROFILE_BASE = 'https://image.tmdb.org/t/p/w500'
+
+export interface PersonCredit {
+  tmdbId: number
+  title: string
+  year: string | null
+  character: string | null
+  posterUrl: string | null
+  popularity: number
+}
+
+export interface Person {
+  id: number
+  name: string
+  biography: string | null
+  birthday: string | null
+  deathday: string | null
+  placeOfBirth: string | null
+  knownForDepartment: string | null
+  profileUrl: string | null
+  credits: PersonCredit[]
+}
+
+export const isTmdbConfigured = () => !!env.TMDB_API_KEY
+
+const tmdbFetch = async (path: string, params: Record<string, string> = {}) => {
+  const key = env.TMDB_API_KEY
+  if (!key) throw new Error('TMDB_API_KEY is not configured')
+
+  const isBearerToken = key.startsWith('eyJ')
+  const url = new URL(`${TMDB_BASE_API_URL}${path}`)
+  for (const [name, value] of Object.entries(params)) {
+    url.searchParams.set(name, value)
+  }
+  if (!isBearerToken) url.searchParams.set('api_key', key)
+
+  const res = await fetch(url, {
+    headers: isBearerToken ? { Authorization: `Bearer ${key}` } : undefined,
+    // People data barely changes; cache aggressively
+    next: { revalidate: 86400 },
+  })
+  if (!res.ok) throw new Error(`TMDB request failed (${res.status}): ${path}`)
+  return res.json()
+}
+
+/**
+ * Look up a person by name and return their profile with acting credits,
+ * most-popular first. Returns null when nobody matches.
+ */
+export const fetchPerson = async (name: string): Promise<Person | null> => {
+  const search = await tmdbFetch('/search/person', {
+    query: name,
+    include_adult: 'false',
+    language: 'en-US',
+    page: '1',
+  })
+  const match = search?.results?.[0]
+  if (!match?.id) return null
+
+  const person = await tmdbFetch(`/person/${match.id}`, {
+    append_to_response: 'movie_credits',
+    language: 'en-US',
+  })
+  if (!person?.id) return null
+
+  const seen = new Set<number>()
+  const credits: PersonCredit[] = (person.movie_credits?.cast ?? [])
+    .filter((credit: { id?: number; title?: string }) => {
+      if (!credit.id || !credit.title || seen.has(credit.id)) return false
+      seen.add(credit.id)
+      return true
+    })
+    .map(
+      (credit: {
+        id: number
+        title: string
+        character?: string
+        release_date?: string
+        poster_path?: string
+        popularity?: number
+      }): PersonCredit => ({
+        tmdbId: credit.id,
+        title: credit.title,
+        year: credit.release_date ? credit.release_date.slice(0, 4) : null,
+        character: credit.character || null,
+        posterUrl: credit.poster_path
+          ? `${POSTER_BASE}${credit.poster_path}`
+          : null,
+        popularity: credit.popularity ?? 0,
+      })
+    )
+    .sort(
+      (a: PersonCredit, b: PersonCredit) => b.popularity - a.popularity
+    )
+
+  return {
+    id: person.id,
+    name: person.name,
+    biography: person.biography || null,
+    birthday: person.birthday || null,
+    deathday: person.deathday || null,
+    placeOfBirth: person.place_of_birth || null,
+    knownForDepartment: person.known_for_department || null,
+    profileUrl: person.profile_path
+      ? `${PROFILE_BASE}${person.profile_path}`
+      : null,
+    credits,
+  }
+}


### PR DESCRIPTION
## Summary
Follow-up to the merged interactive-UX batch (PR #17), fixing three issues found in review and adding in-app people pages.

## Fixes
- **Hero too tall on large screens** — smaller poster, tighter padding, and a smaller title so the panel doesn't tower next to News.
- **Hero didn't auto-rotate on mobile** — a tap fires `mouseenter` (pausing rotation) without a matching `mouseleave`, so one touch froze it permanently. Pause-on-hover now only engages on devices that can actually hover (`matchMedia('(hover: hover)')`).
- **Broken news images** — the RSS feed pulls from Variety, Hollywood Reporter, and Deadline, but only `variety.com` was whitelisted as an image host, so THR/Deadline featured images 400'd through the image optimizer. Added both hosts, plus a fallback to the next story with a working image if one still fails to load.

## People pages (new)
- Cast/crew cards now open an **in-app `/person/[name]` profile** instead of leaving the app: portrait, bio with a read-more expander, life facts, and a most-popular-first filmography grid, powered by TMDB's person endpoints (the Flixster API has no people search).
- Filmography clicks route through **`/api/find-movie`**, which resolves the title/year back to a Flixster `emsVersionId` via the existing search API and redirects to the in-app movie page (falls back to in-app search if Flixster doesn't know the film). Filmography cards are plain anchors, not `next/link`, so viewport prefetching can't burn Flixster API quota on the resolver route.
- New optional **`TMDB_API_KEY`** env var (accepts either a v3 API key or a v4 read access token — auto-detected). Without it, person pages degrade gracefully to an external Rotten Tomatoes search link.

## Verification note
Automated typecheck/lint/build could not be run in the authoring environment (dependency install failed against the registry, no `node_modules`). Changes were reviewed manually; please rely on CI here for the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXbYVwZ7t7DMGk19SYM6A8)_