### PR TITLE
Spill overflow headlines into hero space + swipeable hero on mobile

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -1,10 +1,12 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
+import parse from 'html-react-parser'
+import Balancer from 'react-wrap-balancer'
 import { keepPreviousData } from '@tanstack/react-query'
-import type { HomeData } from '@/types/main'
+import type { HomeData, NewStory } from '@/types/main'
 import type { MovieCardProps } from '@/components/MovieCard/types'
 
 import MovieCard from '@/components/MovieCard/MovieCard'
@@ -17,6 +19,7 @@ import SearchResults from '@/components/SearchResults/SearchResults'
 
 import { api } from '@/utils/api'
 import debounce from '@/utils/debounce'
+import { partitionNews, INITIAL_HEADLINES } from '@/utils/news'
 
 const MovieRow = ({
   title,
@@ -98,6 +101,37 @@ const MiniStrip = ({
   )
 }
 
+/**
+ * The next batch of headlines beyond what News already shows, spilled into
+ * the leftover space below the hero/strip on desktop (the News column is
+ * naturally taller). Hidden on mobile, where News's own "More news" toggle
+ * covers the same stories in place.
+ */
+const MoreHeadlines = ({ stories }: { stories: NewStory[] }) => {
+  if (stories.length === 0) return null
+  return (
+    <section className="hidden lg:block">
+      <h2 className="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-zinc-400">
+        More headlines
+      </h2>
+      <ul className="surface flex flex-col divide-y divide-zinc-800">
+        {stories.map((story) => (
+          <li key={story.id}>
+            <a
+              className="block px-4 py-3 text-sm transition hover:bg-zinc-800/60 hover:text-pink-400"
+              href={story.link}
+              target="_blank"
+              rel="noreferrer"
+            >
+              <Balancer>{parse(story.title)}</Balancer>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
 export default function HomeClient({ data }: { data: HomeData }) {
   // inputValue is what's in the box; query is the debounced value that
   // actually drives the API request
@@ -156,6 +190,16 @@ export default function HomeClient({ data }: { data: HomeData }) {
 
   const hasNews = (news?.length ?? 0) > 0
 
+  // The News column is naturally taller than the compact hero, so the next
+  // batch of headlines (beyond what News already shows) spills into the
+  // leftover space in the left column instead of leaving it empty. Not
+  // memoized off `failedImages` (News tracks that internally) — worst case
+  // is one headline briefly appearing on both sides if a feed image 404s.
+  const moreHeadlines = useMemo(() => {
+    const { restStories } = partitionNews(news)
+    return restStories.slice(INITIAL_HEADLINES, INITIAL_HEADLINES * 2)
+  }, [news])
+
   return (
     <main className="pb-10">
       {!isSearching && (popular.length > 0 || hasNews) && (
@@ -168,6 +212,7 @@ export default function HomeClient({ data }: { data: HomeData }) {
                 title={opening.length > 0 ? 'Opening this week' : 'Coming soon'}
                 movies={opening.length > 0 ? opening : upcoming}
               />
+              <MoreHeadlines stories={moreHeadlines} />
             </div>
           )}
           {hasNews && <News newsStories={news} />}

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
-import type { FC } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { FC, TouchEvent } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { HiChevronLeft, HiChevronRight, HiHeart, HiOutlineHeart } from 'react-icons/hi'
@@ -23,6 +23,8 @@ const Hero: FC<HeroProps> = ({ movies }) => {
   // Bumped on manual navigation so the auto-advance interval restarts and
   // doesn't fire right after a click
   const [restartKey, setRestartKey] = useState(0)
+  // Swipe-gesture tracking (see handleTouchStart/End below)
+  const touchStart = useRef<{ x: number; y: number } | null>(null)
 
   const goTo = useCallback(
     (next: number) => {
@@ -51,11 +53,37 @@ const Hero: FC<HeroProps> = ({ movies }) => {
     if (window.matchMedia('(hover: hover)').matches) setPaused(true)
   }
 
+  // The arrow buttons only reveal on hover, so touch devices had no way to
+  // navigate besides waiting or tapping a dot — track a swipe gesture too.
+  // No touchmove/preventDefault: we only act on total displacement at
+  // touchend, so vertical page scrolling is never interfered with.
+  const SWIPE_THRESHOLD = 40
+
+  const handleTouchStart = (e: TouchEvent) => {
+    const touch = e.touches[0]
+    touchStart.current = { x: touch.clientX, y: touch.clientY }
+  }
+
+  const handleTouchEnd = (e: TouchEvent) => {
+    const start = touchStart.current
+    touchStart.current = null
+    if (!start) return
+    const touch = e.changedTouches[0]
+    const deltaX = touch.clientX - start.x
+    const deltaY = touch.clientY - start.y
+    if (Math.abs(deltaX) < SWIPE_THRESHOLD || Math.abs(deltaX) < Math.abs(deltaY)) {
+      return
+    }
+    goTo(deltaX < 0 ? index + 1 : index - 1)
+  }
+
   return (
     <section
       className="group/hero relative overflow-hidden rounded-2xl"
       onMouseEnter={pauseIfHoverDevice}
       onMouseLeave={() => setPaused(false)}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
       aria-roledescription="carousel"
       aria-label="Popular movies spotlight"
     >

--- a/src/components/News/News.tsx
+++ b/src/components/News/News.tsx
@@ -8,25 +8,21 @@ import { useState } from 'react'
 import Image from 'next/image'
 import parse from 'html-react-parser'
 import Balancer from 'react-wrap-balancer'
-
-const INITIAL_STORIES = 8
+import { partitionNews, INITIAL_HEADLINES } from '@/utils/news'
 
 const News: FC<NewsStoryProps> = ({ newsStories }) => {
   const [expanded, setExpanded] = useState(false)
   // Feed images can 404 or come from a host we can't render — when one
   // fails, fall back to the next story that has a working image
   const [failedImages, setFailedImages] = useState<Set<string>>(new Set())
-  const stories = (newsStories || []).filter(
-    (story) => !story.title?.toLowerCase().includes('tv')
+  const { stories, mainStory, restStories } = partitionNews(
+    newsStories,
+    failedImages
   )
-  const mainStory = stories.find(
-    (story) => story.mainImage?.url && !failedImages.has(story.mainImage.url)
-  )
-  const restStories = stories.filter((story) => story.id !== mainStory?.id)
   const visibleStories = expanded
     ? restStories
-    : restStories.slice(0, INITIAL_STORIES)
-  const hiddenCount = restStories.length - INITIAL_STORIES
+    : restStories.slice(0, INITIAL_HEADLINES)
+  const hiddenCount = restStories.length - INITIAL_HEADLINES
 
   // Nothing to show (the news feed is sometimes empty) — render nothing
   // rather than a stray heading
@@ -80,10 +76,12 @@ const News: FC<NewsStoryProps> = ({ newsStories }) => {
               </li>
             ))}
           </ul>
+          {/* On desktop the overflow already fills the space beside the
+              hero (see HomeClient), so this toggle is mobile-only there */}
           {hiddenCount > 0 && (
             <button
               onClick={() => setExpanded((current) => !current)}
-              className="border-t border-zinc-800 px-4 py-3 text-sm font-semibold text-pink-400 transition hover:bg-zinc-800/60 hover:text-pink-300"
+              className="border-t border-zinc-800 px-4 py-3 text-sm font-semibold text-pink-400 transition hover:bg-zinc-800/60 hover:text-pink-300 lg:hidden"
             >
               {expanded ? 'Show less' : `More news (${hiddenCount})`}
             </button>

--- a/src/utils/news.ts
+++ b/src/utils/news.ts
@@ -1,0 +1,26 @@
+import type { NewStory } from '@/types/main'
+
+// How many headlines the News card shows before its own "More news" toggle
+// (mobile) — and, on desktop, before the overflow spills into the leftover
+// space beside the hero (see HomeClient's headline-fill panel). Keeping this
+// in one place keeps the two split points in sync.
+export const INITIAL_HEADLINES = 8
+
+/**
+ * Filters out TV coverage and picks the featured (image-bearing) story.
+ * Shared by News and HomeClient so both compute the same rest-of-list
+ * ordering when splitting headlines across the two-column layout.
+ */
+export const partitionNews = (
+  newsStories: NewStory[] | undefined,
+  failedImageUrls: Set<string> = new Set()
+) => {
+  const stories = (newsStories || []).filter(
+    (story) => !story.title?.toLowerCase().includes('tv')
+  )
+  const mainStory = stories.find(
+    (story) => story.mainImage?.url && !failedImageUrls.has(story.mainImage.url)
+  )
+  const restStories = stories.filter((story) => story.id !== mainStory?.id)
+  return { stories, mainStory, restStories }
+}


### PR DESCRIPTION
## Summary
Two follow-ups from PR #20 feedback.

## Headline spill (desktop layout)
The opening-this-week poster strip helped but didn't close the full height gap between the hero column and the taller News column.
- The next batch of headlines beyond what News already shows (stories 9–16) now renders as a compact "More headlines" list under the poster strip, desktop-only (`hidden lg:block`).
- Extracted the TV-filter/featured-story-pick logic that News used internally into a shared `partitionNews()` helper (`src/utils/news.ts`), so News and HomeClient split the same ordered headline list consistently instead of duplicating that logic.
- News's own "More news" expand toggle is now mobile-only (`lg:hidden`) — on desktop its overflow is already visible in the left column, so showing the toggle there would just be redundant.

## Swipeable hero (mobile)
The prev/next arrows only ever reveal on hover (`sm:group-hover/hero:flex`), so touch devices had no way to navigate the 5-movie hero besides waiting for auto-rotate or tapping a dot.
- Added touchstart/touchend tracking: a sufficiently large, mostly-horizontal swipe advances or retreats a slide.
- No `touchmove`/`preventDefault` — the decision happens once at `touchend` from total displacement, so vertical page scrolling is never intercepted.

## Verification note
Automated typecheck/lint/build could not be run in the authoring environment (registry unreachable, no `node_modules`). Please rely on CI for the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)