### PR TITLE
Fix build: guard possibly-undefined touch in Hero swipe handlers

### DIFF
--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -61,14 +61,15 @@ const Hero: FC<HeroProps> = ({ movies }) => {
 
   const handleTouchStart = (e: TouchEvent) => {
     const touch = e.touches[0]
+    if (!touch) return
     touchStart.current = { x: touch.clientX, y: touch.clientY }
   }
 
   const handleTouchEnd = (e: TouchEvent) => {
     const start = touchStart.current
     touchStart.current = null
-    if (!start) return
     const touch = e.changedTouches[0]
+    if (!start || !touch) return
     const deltaX = touch.clientX - start.x
     const deltaY = touch.clientY - start.y
     if (Math.abs(deltaX) < SWIPE_THRESHOLD || Math.abs(deltaX) < Math.abs(deltaY)) {


### PR DESCRIPTION
## Summary
Hotfix for a build break introduced in PR #21.

`tsconfig.json` has `noUncheckedIndexedAccess` enabled, so `e.touches[0]` and `e.changedTouches[0]` in the new Hero swipe handlers type as `Touch | undefined`, not `Touch`. Added guards before use in both `handleTouchStart` and `handleTouchEnd`.

Also manually re-checked every other array-index access touched across this session's changes (ProfileStats sort comparators, the TMDB fetchers, the find-movie resolver) — all already safe via tuple typing, `any`-typed JSON, or existing optional chaining/guards. This was the only unguarded spot.

## Verification note
Still unable to run `tsc`/`npm install` in the authoring environment (registry unreachable). This is a narrow, well-understood fix for the exact reported error; please confirm via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXbYVwZ7t7DMGk19SYM6A8)_