### PR TITLE
Let overflow headlines fully match and fill the News list's space

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -118,7 +118,9 @@ const MoreHeadlines = ({ stories }: { stories: NewStory[] }) => {
         {stories.map((story) => (
           <li key={story.id}>
             <a
-              className="block px-4 py-3 text-sm transition hover:bg-zinc-800/60 hover:text-pink-400"
+              // Same row styling as News's headline list, so a row here
+              // takes up the same vertical space as one over there
+              className="block px-4 py-3 text-base transition hover:bg-zinc-800/60 hover:text-pink-400 lg:text-lg"
               href={story.link}
               target="_blank"
               rel="noreferrer"
@@ -190,14 +192,16 @@ export default function HomeClient({ data }: { data: HomeData }) {
 
   const hasNews = (news?.length ?? 0) > 0
 
-  // The News column is naturally taller than the compact hero, so the next
-  // batch of headlines (beyond what News already shows) spills into the
-  // leftover space in the left column instead of leaving it empty. Not
-  // memoized off `failedImages` (News tracks that internally) — worst case
-  // is one headline briefly appearing on both sides if a feed image 404s.
+  // The News column is naturally taller than the compact hero, so every
+  // headline beyond what News already shows spills into the leftover space
+  // in the left column instead of leaving it empty (fetchNews caps the feed
+  // at 20 stories, so this list is bounded even without a slice end here).
+  // Not memoized off `failedImages` (News tracks that internally) — worst
+  // case is one headline briefly appearing on both sides if a feed image
+  // 404s.
   const moreHeadlines = useMemo(() => {
     const { restStories } = partitionNews(news)
-    return restStories.slice(INITIAL_HEADLINES, INITIAL_HEADLINES * 2)
+    return restStories.slice(INITIAL_HEADLINES)
   }, [news])
 
   return (


### PR DESCRIPTION
## Summary
Two adjustments to the desktop headline-spill panel (under the hero/strip) so it uses the leftover space as fully as News's own list does.

## Change
- **Row typography now matches News's headline list** (`text-base lg:text-lg`) instead of the smaller `text-sm` it had — each row in the spill panel now takes up the same vertical space as a row in News, instead of reading as a cramped secondary list.
- **Dropped the fixed 8-item cap** — the panel previously showed exactly headlines 9–16 (`slice(8, 16)`) regardless of how many were actually left over. It now shows every remaining headline (`slice(8)`), using as much real content as is available. `fetchNews` already caps the feed at 20 stories total, so this stays naturally bounded.

## Verification note
Automated typecheck/lint/build could not be run in the authoring environment (registry unreachable, no `node_modules`). Please rely on CI for the authoritative check — will wait for the Vercel build to report success before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXbYVwZ7t7DMGk19SYM6A8)_