### PR TITLE
Cut Flixster API usage with much longer cache windows

### DIFF
--- a/src/app/movie/[id]/page.tsx
+++ b/src/app/movie/[id]/page.tsx
@@ -4,7 +4,9 @@ import { notFound } from 'next/navigation'
 import { fetchDetails } from '@/server/flixster'
 import MovieDetails from '@/components/MovieDetails/MovieDetails'
 
-export const revalidate = 3600
+// Movie facts are effectively static — regenerate at most weekly to keep
+// Flixster API usage low (see src/server/flixster.ts).
+export const revalidate = 604800
 
 type PageProps = { params: Promise<{ id: string }> }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,8 +3,11 @@ import { fetchPopular, fetchUpcoming } from '@/server/flixster'
 import { fetchNews } from '@/server/news'
 import HomeClient from './HomeClient'
 
-// ISR: rebuild the home data at most once an hour
-export const revalidate = 3600
+// ISR: rebuild the home data at most twice a day. Kept long on purpose —
+// each rebuild spends against the Flixster API's monthly quota even with no
+// traffic (see src/server/flixster.ts). The per-fetch cache windows there
+// govern the finer-grained freshness of each section.
+export const revalidate = 43200
 
 export default async function Page() {
   // Each source falls back independently so one failing call can't blank the page

--- a/src/server/flixster.ts
+++ b/src/server/flixster.ts
@@ -2,7 +2,14 @@
  * Server-only Flixster fetchers. The RapidAPI key comes from the validated
  * server env, so this module must never be imported into client code. Both
  * the tRPC flixster router and the App Router Server Components use it.
+ *
+ * Cache windows are deliberately long: the RapidAPI plan has a hard monthly
+ * quota, and every timer-based revalidation spends against it whether or not
+ * anyone is looking. Movie facts are effectively static, so they're cached
+ * for a week; the "popular"/"opening" lists refresh twice a day, which is
+ * plenty for a "today"/"this week" surface.
  */
+import { cache } from 'react'
 import { env } from '../env/server.mjs'
 import {
   RAPID_API_HOST,
@@ -12,13 +19,21 @@ import {
   FLIXSTER_API_MOVIE_DETAILS_URL,
 } from '@/data/Constants'
 
+// Cache lifetimes in seconds (see module note on quota)
+export const REVALIDATE = {
+  popular: 43_200, // 12h
+  upcoming: 86_400, // 24h
+  details: 604_800, // 7d — movie metadata basically never changes
+  search: 86_400, // 24h — results for a given query are stable
+} as const
+
 const headers = {
   'X-RapidAPI-Key': env.RAPID_API_KEY,
   'X-RapidAPI-Host': RAPID_API_HOST,
 }
 
 // revalidate is the Next data-cache lifetime in seconds
-const fetchFlixster = async (url: string, revalidate = 3600) => {
+const fetchFlixster = async (url: string, revalidate: number) => {
   const res = await fetch(url, { headers, next: { revalidate } })
   if (!res.ok) {
     throw new Error(`Flixster request failed (${res.status})`)
@@ -27,7 +42,7 @@ const fetchFlixster = async (url: string, revalidate = 3600) => {
 }
 
 export const fetchPopular = async () => {
-  const data = await fetchFlixster(FLIXSTER_API_POPULAR_URL)
+  const data = await fetchFlixster(FLIXSTER_API_POPULAR_URL, REVALIDATE.popular)
   return {
     opening: data?.data?.opening ?? [],
     popularity: data?.data?.popularity ?? [],
@@ -35,21 +50,28 @@ export const fetchPopular = async () => {
 }
 
 export const fetchUpcoming = async () => {
-  const data = await fetchFlixster(FLIXSTER_API_UPCOMING_URL)
+  const data = await fetchFlixster(
+    FLIXSTER_API_UPCOMING_URL,
+    REVALIDATE.upcoming
+  )
   return data?.data?.upcoming ?? []
 }
 
 export const fetchSearch = async (query: string) => {
   const data = await fetchFlixster(
     `${FLIXSTER_API_SEARCH_URL}${encodeURIComponent(query)}`,
-    300
+    REVALIDATE.search
   )
   return data?.data?.search?.movies ?? []
 }
 
-export const fetchDetails = async (id: string) => {
+// Wrapped in React cache() so the movie page's generateMetadata and the page
+// component share a single call within one request instead of hitting the
+// API (or even the data cache) twice per render.
+export const fetchDetails = cache(async (id: string) => {
   const data = await fetchFlixster(
-    `${FLIXSTER_API_MOVIE_DETAILS_URL}${encodeURIComponent(id)}`
+    `${FLIXSTER_API_MOVIE_DETAILS_URL}${encodeURIComponent(id)}`,
+    REVALIDATE.details
   )
   return data?.data?.movie ?? null
-}
+})


### PR DESCRIPTION
## Summary
The Flixster RapidAPI plan hit 100% of its monthly quota. The dominant cause is timer-based ISR revalidation, which spends API calls on a schedule regardless of traffic: the homepage revalidated **hourly** (≈2 calls/hour = ~1,440 calls/month on its own), and movie detail pages hourly too. This raises all cache windows substantially.

## Changes
- **Homepage ISR** `1h → 12h`; popular/opening fetch `1h → 12h`, upcoming `1h → 24h`. A "today"/"this week" surface stays plenty fresh at twice-daily.
- **Movie detail page ISR + details fetch** `1h → 7d` — movie metadata is effectively static.
- **Search cache** `5m → 24h` — results for a given query are stable.
- **`fetchDetails` wrapped in React `cache()`** so a movie page's `generateMetadata` and page component share a single call per request instead of two.
- Cache lifetimes centralized in a `REVALIDATE` map in `src/server/flixster.ts`.

No behavior change beyond freshness windows. `quickAdd` and the cast → find-movie resolver already ride the same data cache, so longer windows cut their calls too (a recently-seen movie/query is a cache hit).

## Note on further reduction
A big amplifier during today's rapid iteration is that each Vercel **deployment can reset the data cache**, forcing cold refetches on the next view — steady-state will be far lower than the last few days suggested. If quota is still tight, the next lever is a persistent movie-details cache in the existing Postgres DB (so cache survives deploys); happy to add that as a follow-up.

## Verification note
`npm install`/`tsc` still can't run in the authoring environment (registry unreachable). Changes are config/constants + a `cache()` wrapper. Will wait for the Vercel build to report success before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXbYVwZ7t7DMGk19SYM6A8)_