### PR TITLE
Run Prisma migrations automatically on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "next build",
+    "build": "prisma migrate deploy && next build",
     "dev": "next dev",
     "postinstall": "prisma generate",
     "lint": "next lint",


### PR DESCRIPTION
Prefixes the build with `prisma migrate deploy` so Vercel applies any pending migrations against the production database (using the `DATABASE_URL` already configured there) on every deploy.

This applies the `20260703000000_public_watchlist_and_alerts` migration (`User.publicWatchlist`, `User.streamAlerts`, `WatchListItem.hasStreaming`) on the next deploy, and handles future migrations automatically — no manual `migrate deploy` step needed.

Works against any Postgres host (the datasource is provider-agnostic `postgresql` + a plain PrismaClient), including Neon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzEYYixAPGiVZB6Db49UXt

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzEYYixAPGiVZB6Db49UXt)_