### PR TITLE
Revert running Prisma migrate on build (fixes failing deploy)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "prisma migrate deploy && next build",
+    "build": "next build",
     "dev": "next dev",
     "postinstall": "prisma generate",
     "lint": "next lint",


### PR DESCRIPTION
The production build started failing with Prisma `P3005` ("The database schema is not empty"): the prod DB has all tables but no Prisma migration history (it was set up via `prisma db push`), so `prisma migrate deploy` refuses to run against it.

Reverts the build back to `next build` so deploys succeed. The new `publicWatchlist` / `streamAlerts` / `hasStreaming` columns still need to be applied to the database out-of-band — either a one-time `prisma db push`, or baselining the DB (`prisma migrate resolve --applied 20230118034324_movie_fan_v5`) and then `prisma migrate deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzEYYixAPGiVZB6Db49UXt

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzEYYixAPGiVZB6Db49UXt)_