### PR TITLE
Hotfix: add missing DB columns at build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "next build",
+    "build": "prisma db execute --schema ./prisma/schema.prisma --file ./prisma/hotfix.sql && next build",
     "dev": "next dev",
     "postinstall": "prisma generate",
     "lint": "next lint",

--- a/prisma/hotfix.sql
+++ b/prisma/hotfix.sql
@@ -1,0 +1,7 @@
+-- One-shot hotfix: add the columns the app already expects to a database that
+-- was created via `prisma db push` (no migration history, so `migrate deploy`
+-- can't run). Idempotent + additive, so it's safe to run repeatedly and causes
+-- no data loss. Applied at build time via `prisma db execute`, then removed.
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "publicWatchlist" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "streamAlerts" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "WatchListItem" ADD COLUMN IF NOT EXISTS "hasStreaming" BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
Production auth is currently failing — the Auth.js adapter's `getSessionAndUser` reads the full `User` row, and the DB is missing `publicWatchlist` / `streamAlerts` / `hasStreaming` (`column "User.publicWatchlist" does not exist`).

The DB was created via `prisma db push` (no migration history), so `migrate deploy` can't apply them (P3005). This runs idempotent, additive `ADD COLUMN IF NOT EXISTS` DDL via `prisma db execute` during the build, where `DATABASE_URL` is available, to add the columns with zero data loss.

Follow-up PR reverts the build back to `next build` and removes the hotfix file once the columns are applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzEYYixAPGiVZB6Db49UXt

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzEYYixAPGiVZB6Db49UXt)_