### PR TITLE
Remove build-time DB hotfix; fix movie page not scrolling to top

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "prisma db execute --schema ./prisma/schema.prisma --file ./prisma/hotfix.sql && next build",
+    "build": "next build",
     "dev": "next dev",
     "postinstall": "prisma generate",
     "lint": "next lint",

--- a/prisma/hotfix.sql
+++ b/prisma/hotfix.sql
@@ -1,7 +1,0 @@
--- One-shot hotfix: add the columns the app already expects to a database that
--- was created via `prisma db push` (no migration history, so `migrate deploy`
--- can't run). Idempotent + additive, so it's safe to run repeatedly and causes
--- no data loss. Applied at build time via `prisma db execute`, then removed.
-ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "publicWatchlist" BOOLEAN NOT NULL DEFAULT false;
-ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "streamAlerts" BOOLEAN NOT NULL DEFAULT false;
-ALTER TABLE "WatchListItem" ADD COLUMN IF NOT EXISTS "hasStreaming" BOOLEAN NOT NULL DEFAULT false;

--- a/src/components/MovieDetails/MovieDetails.tsx
+++ b/src/components/MovieDetails/MovieDetails.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import Balancer from 'react-wrap-balancer'
@@ -103,6 +103,13 @@ const MovieDetails = ({ id, movie }: { id: string; movie: IMovieDetail }) => {
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null)
   const [copied, setCopied] = useState(false)
   const [showTrailer, setShowTrailer] = useState(false)
+
+  // Navigating movie→movie (e.g. via "More like this") stays on the same
+  // /movie/[id] route segment, which the App Router reuses without resetting
+  // scroll — so jump to the top whenever the movie changes.
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [id])
 
   const invalidateWatchlist = () => {
     utils.movie.query.invalidate({ movieId: id })


### PR DESCRIPTION
Two things:

- **Remove the build-time hotfix.** The `publicWatchlist` / `streamAlerts` / `hasStreaming` columns are now applied to the database, so revert the build back to `next build` and delete `prisma/hotfix.sql` (it no longer needs to run on every deploy).
- **Fix movie detail pages not scrolling to top.** Navigating movie→movie (e.g. via the new "More like this" row, or from a person/search result) stays on the same `/movie/[id]` route segment, which the App Router reuses without resetting scroll — so the new movie could open mid-page. `MovieDetails` now scrolls to the top whenever the movie id changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzEYYixAPGiVZB6Db49UXt

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzEYYixAPGiVZB6Db49UXt)_