### PR TITLE
Cut Vercel free-tier burn: block person-page crawl, stop image optimization

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -23,6 +23,13 @@ const config = {
   // Pin the workspace root so a stray lockfile elsewhere doesn't confuse tracing
   outputFileTracingRoot: process.cwd(),
   images: {
+    // Serve remote images directly instead of through /_next/image. Every
+    // optimized image is a metered Vercel edge request + transformation, and
+    // with ~20 posters per page that multiplier was the main driver of blowing
+    // the free tier's edge-request quota. TMDB already serves size-appropriate
+    // renditions (w342/w500/w780), so on-the-fly optimization buys little here.
+    // Trade-off: no AVIF/WebP re-encoding and no responsive srcset.
+    unoptimized: true,
     remotePatterns: imageHosts.map((hostname) => ({
       protocol: 'https',
       hostname,

--- a/src/app/person/[slug]/page.tsx
+++ b/src/app/person/[slug]/page.tsx
@@ -43,6 +43,9 @@ export async function generateMetadata({
   return {
     title: label,
     description: `Movies featuring ${label}`,
+    // Person pages are also disallowed in robots.txt (see src/app/robots.ts) —
+    // the unbounded movie↔person link graph made crawlers a quota problem
+    robots: { index: false },
   }
 }
 

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -7,8 +7,13 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: '*',
       allow: '/',
-      // Auth and API surfaces aren't useful to crawlers
-      disallow: ['/api/', '/profile', '/signin'],
+      // Auth and API surfaces aren't useful to crawlers. /person/ and /u/ are
+      // blocked deliberately: every movie page links to dozens of person pages
+      // (each a unique URL that misses the ISR cache), so an obedient crawler
+      // walking that graph burns tens of thousands of function invocations a
+      // day for thin, TMDB-sourced content. Movie and genre pages remain
+      // indexable — they're the content that matters.
+      disallow: ['/api/', '/profile', '/signin', '/person/', '/u/'],
     },
     sitemap: `${base}/sitemap.xml`,
   }

--- a/src/app/u/[id]/page.tsx
+++ b/src/app/u/[id]/page.tsx
@@ -22,6 +22,9 @@ export async function generateMetadata({
   return {
     title: `${owner}'s watchlist`,
     description: `${owner}'s movie watchlist on Movie Fan`,
+    // Shared-by-link user content; also disallowed in robots.txt. force-dynamic
+    // means every crawler hit is an uncached function + DB query.
+    robots: { index: false },
   }
 }
 


### PR DESCRIPTION
## Summary
- Usage alerts hit 100% of the Edge Requests quota (1M) and 75% of Function Duration. Runtime logs traced it to a crawler walking the movie↔person link graph: 36,171 distinct `/person/...` renders in 24h (vs ~3,700 movie pages), each a unique URL that misses the ISR cache and each page pulling ~20 posters through Vercel's metered image optimizer.
- `robots.txt` now disallows `/person/` and `/u/` (thin TMDB-sourced and shared-by-link content; movie and genre pages stay indexable), and both page types emit a `noindex` robots meta so already-discovered URLs get dropped instead of re-crawled.
- `next/image` is set `unoptimized: true`: images now load directly from TMDB's CDN (which already serves size-appropriate renditions — w342/w500/w780) instead of through Vercel's per-request image optimizer. Trade-off: no AVIF/WebP re-encoding or responsive srcset.

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `next lint` — clean
- [x] `next build` — succeeds, all routes generate
- [x] `vitest run` — 27/27 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011WDdr1Jarx13CfRMwo9DYn)_